### PR TITLE
Fix: Add the actual paths to the tabs (#52)

### DIFF
--- a/app/views/patients/anthropometrics/new.html.erb
+++ b/app/views/patients/anthropometrics/new.html.erb
@@ -1,243 +1,168 @@
-<div class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog" aria-modal="true">
-    <div class="absolute inset-0 overflow-hidden">
-      <!--
-        Background overlay, show/hide based on slide-over state.
-  
-        Entering: "ease-in-out duration-500"
-          From: "opacity-0"
-          To: "opacity-100"
-        Leaving: "ease-in-out duration-500"
-          From: "opacity-100"
-          To: "opacity-0"
-      -->
-      <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-      <div class="fixed inset-y-0 right-0 pl-10 max-w-full flex">
-        <!--
-          Slide-over panel, show/hide based on slide-over state.
-  
-          Entering: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-full"
-            To: "translate-x-0"
-          Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-0"
-            To: "translate-x-full"
-        -->
-        <div class="relative w-screen max-w-3xl">
-          <!--
-            Close button, show/hide based on slide-over state.
-  
-            Entering: "ease-in-out duration-500"
-              From: "opacity-0"
-              To: "opacity-100"
-            Leaving: "ease-in-out duration-500"
-              From: "opacity-100"
-              To: "opacity-0"
-          -->
-          <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
-            <button type="button" class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
-              <span class="sr-only">Close panel</span>
-              <!-- Heroicon name: outline/x -->
-              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-  
-          <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
-            <div class="px-4 sm:px-6 mt-4">
-                <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
-                    Expediente
-                </h2>
-                <div class="mt-5">
-                    <div class="sm:hidden">
-                    <label for="tabs" class="sr-only">Select a tab</label>
-                    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-                    <select id="tabs" name="tabs" class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md">
-                        <option>Generales</option>
-
-												<option >Historial</option>
-                
-                        <option selected>Antropométrico</option>
-                
-                        <option>Hábitos</option>
-                
-                        <option>Actividad física</option>
-
-                        <option>Notas</option>
-                    </select>
-                    </div>
-                    <div class="hidden sm:block">
-                    <nav class="flex space-x-4" aria-label="Tabs">
-                        <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
-                        <a href="general" class="text-gray-500  hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Generales
-                        </a>
-
-                        <a href="history" class= "text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md"  >
-                        Historial
-                        </a>
-
-												<a href="anthropometric" class="bg-indigo-100 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md" aria-current="page">
-                        Antropométrico
-                        </a>
-                
-                        <a href="habits" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Hábitos
-                        </a>
-
-                        <a href="physical_activity" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Actividad física
-                        </a>
-                
-                        <a href="notes" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Notas
-                        </a>
-                    </nav>
-                    </div>
-                </div>
-  
-            </div>
-						
-             <div class="mt-2 relative flex-1 overflow-y-auto">
-              <!-- Replace with your content --> 
+<turbo-frame turbo-frame data-controller="operation-tabs-shower" data-operation-tabs-shower-target="turboFrame"
+    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame" id="anthropometric">
+    <div class="border-t border-gray-200">
+        <div class="mt-2 relative flex-1 overflow-y-auto">
+            <!-- Replace with your content -->
             <div class="bg-gray-100 w-full px-6 py-5">
                 <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
                             <h3>Datos generales</h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                        
-										<div class="mt-5 md:mt-5 md:col-span-3">
-												<form action="#" method="POST">
-														<div class="grid grid-cols-9 gap-6">
-																<div class="col-span-6 sm:col-span-3">
-																<label for="size" class="text-sm">Talla (m)</label>
-																<input type="number" step="any" name="size" id="size" autocomplete="size" class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
-																</div>
-										
-																<div class="col-span-6 sm:col-span-3">
-																<label for="weight" class="text-sm">Peso (kg)</label>
-																<input type="number" step="any" name="weight" id="weight" autocomplete="weight" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
 
-																<div class="col-span-6 sm:col-span-3">
-																<label for="imc" class="text-sm">IMC (kg/m2)</label>
-																
-																	<h3 class="mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md">
-																			0
-																	</h3>
-																	
-															</div>
-											
-																<div class="col-span-6 sm:col-span-3">
-																<label for="normal-weight" class="text-sm">Peso habitual (kg)</label>
-																<input type="number" step="any" name="normal-weight" id="normal-weight" autocomplete="normal-weight" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
+                            <div class="mt-5 md:mt-5 md:col-span-3">
+                                <form action="#" method="POST">
+                                    <div class="grid grid-cols-9 gap-6">
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="size" class="text-sm">Talla (m)</label>
+                                            <input type="number" step="any" name="size" id="size" autocomplete="size"
+                                                class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
+                                        </div>
 
-																
-														</div>
-												</form>
-										</div>
-								</div>
-						</div>
-				</div> <!-- fin card datos generales-->
-			</div>
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="weight" class="text-sm">Peso (kg)</label>
+                                            <input type="number" step="any" name="weight" id="weight"
+                                                autocomplete="weight"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
 
-					<!-- Circunferencia --> 
-			<div class="bg-gray-100 w-full px-6 py-5">
-				<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-						<div class="md:grid md:grid-cols-3 md:gap-6">
-								<div class="md:col-span-3">
-										<h3 >Circunferencia </h3>
-										<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-								
-										<div class="mt-5 md:mt-5 md:col-span-3">
-												<form action="#" method="POST">
-														<div class="grid grid-cols-6 gap-6">
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="waist" class="text-sm">Cintura (cm)</label>
-																	<input type="number" step="any" name="waist" id="waist" autocomplete="waist" class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
-																</div>
-										
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="hip" class="text-sm">Cadera (cm)</label>
-																	<input type="number" step="any" name="hip" id="hip" autocomplete="hip" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="imc" class="text-sm">IMC (kg/m2)</label>
 
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="relaxed-arm" class="text-sm">Brazo relajado (cm)</label>
-																	<input type="number" step="any" name="relaxed-arm" id="relaxed-arm" autocomplete="relaxed-arm" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
-																
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="contracted-arm" class="text-sm">Brazo contraído (cm)</label>
-																	<input type="number" step="any" name="contracted-arm" id="contracted-arm" autocomplete="contracted-arm" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
+                                            <h3
+                                                class="mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md">
+                                                0
+                                            </h3>
 
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="calf" class="text-sm">Pantorrilla (cm)</label>
-																	<input type="number" step="any" name="calf" id="calf" autocomplete="calf" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
+                                        </div>
 
-																
-														</div>
-												</form>
-										</div>
-								</div>
-						</div>
-				</div> <!-- fin circunferencia-->
-			</div>
-					<!-- Composición corporal --> 
-			<div class="bg-gray-100 w-full px-6 py-5">
-				<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-						<div class="md:grid md:grid-cols-3 md:gap-6">
-								<div class="md:col-span-3">
-										<h3 class="text-lg font-medium leading-6 text-gray-900">Composición corporal </h3>
-										<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-								
-										<div class="mt-5 md:mt-5 md:col-span-3">
-												<form action="#" method="POST">
-														<div class="grid grid-cols-6 gap-6">
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="fat-percentage" class="text-sm">Porcentaje de grasa (%)</label>
-																	<input type="number" step="any" name="fat-percentage" id="fat-percentage" autocomplete="fat-percentage" class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
-																</div>
-										
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="kg-fat" class="text-sm">Kg de grasa*</label>
-																	<h3 class="mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md">
-																		0%
-																	</h3>
-																</div>
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="normal-weight" class="text-sm">Peso habitual (kg)</label>
+                                            <input type="number" step="any" name="normal-weight" id="normal-weight"
+                                                autocomplete="normal-weight"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
 
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="muscle-mass" class="text-sm">Masa muscular (kg)</label>
-																	<input type="number" step="any" name="muscle-mass" id="muscle-mass" autocomplete="muscule-mass" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
-																
-																<div class="col-span-6 sm:col-span-3">
-																	<label for="body-water" class="text-sm">Agua corporal (L)</label>
-																	<input type="number" step="any" name="body-water" id="body-water" autocomplete="body-water" class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																</div>
 
-																
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin card datos generales-->
+            </div>
 
-																
-														</div>
+            <!-- Circunferencia -->
+            <div class="bg-gray-100 w-full px-6 py-5">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Circunferencia </h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
 
-																<div class="col-span-6 sm:col-span-4 mt-8">
-																	<label for="bioimpedance" class="text-sm">Bioimpedancia</label>
-																	<button type="button" class="relative block w-full border-2 border-gray-300 border-dashed rounded-lg p-2 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 mt-1">
-																		<svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-																			<path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-																		</svg>
-																		<span class="mt-2 block text-sm font-medium text-gray-900">
-																			Agregar archivo
-																		</span>
-																	</button>
-																</div>
-												</form>
-										</div>
-								</div>
-						</div>
-				</div> <!-- fin Composición Corporal-->
+                            <div class="mt-5 md:mt-5 md:col-span-3">
+                                <form action="#" method="POST">
+                                    <div class="grid grid-cols-6 gap-6">
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="waist" class="text-sm">Cintura (cm)</label>
+                                            <input type="number" step="any" name="waist" id="waist" autocomplete="waist"
+                                                class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="hip" class="text-sm">Cadera (cm)</label>
+                                            <input type="number" step="any" name="hip" id="hip" autocomplete="hip"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="relaxed-arm" class="text-sm">Brazo relajado (cm)</label>
+                                            <input type="number" step="any" name="relaxed-arm" id="relaxed-arm"
+                                                autocomplete="relaxed-arm"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="contracted-arm" class="text-sm">Brazo contraído (cm)</label>
+                                            <input type="number" step="any" name="contracted-arm" id="contracted-arm"
+                                                autocomplete="contracted-arm"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="calf" class="text-sm">Pantorrilla (cm)</label>
+                                            <input type="number" step="any" name="calf" id="calf" autocomplete="calf"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
+
+
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin circunferencia-->
+            </div>
+            <!-- Composición corporal -->
+            <div class="bg-gray-100 w-full px-6 py-5">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3 class="text-lg font-medium leading-6 text-gray-900">Composición corporal </h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+
+                            <div class="mt-5 md:mt-5 md:col-span-3">
+                                <form action="#" method="POST">
+                                    <div class="grid grid-cols-6 gap-6">
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="fat-percentage" class="text-sm">Porcentaje de grasa (%)</label>
+                                            <input type="number" step="any" name="fat-percentage" id="fat-percentage"
+                                                autocomplete="fat-percentage"
+                                                class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="kg-fat" class="text-sm">Kg de grasa*</label>
+                                            <h3
+                                                class="mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md">
+                                                0%
+                                            </h3>
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="muscle-mass" class="text-sm">Masa muscular (kg)</label>
+                                            <input type="number" step="any" name="muscle-mass" id="muscle-mass"
+                                                autocomplete="muscule-mass"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <label for="body-water" class="text-sm">Agua corporal (L)</label>
+                                            <input type="number" step="any" name="body-water" id="body-water"
+                                                autocomplete="body-water"
+                                                class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                        </div>
+                                    </div>
+
+                                    <div class="col-span-6 sm:col-span-4 mt-8">
+                                        <label for="bioimpedance" class="text-sm">Bioimpedancia</label>
+                                        <button type="button"
+                                            class="relative block w-full border-2 border-gray-300 border-dashed rounded-lg p-2 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 mt-1">
+                                            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24"
+                                                stroke="currentColor" aria-hidden="true">
+                                                <path vector-effect="non-scaling-stroke" stroke-linecap="round"
+                                                    stroke-linejoin="round" stroke-width="2"
+                                                    d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+                                            </svg>
+                                            <span class="mt-2 block text-sm font-medium text-gray-900">
+                                                Agregar archivo
+                                            </span>
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin Composición Corporal-->
+            </div>
+</turbo-frame>

--- a/app/views/patients/expedients/general.html.erb
+++ b/app/views/patients/expedients/general.html.erb
@@ -114,6 +114,29 @@
                                                         vida saludable</label>
                                                 </div>
                                             </div>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div> <!-- fin card información personal-->
+                </div>
+                <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Motivo de consulta</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+                            <div class="mt-3 md:mt-3 md:col-span-3">
+                                <fieldset>
+                                    <legend class="text-base font-medium text-gray-900"></legend>
+                                    <div class="mt-4 space-y-4">
+                                        <div class="flex items-start">
+                                            <div class="h-5 flex items-center">
+                                                <input id="comments" name="comments" type="checkbox" class="checkbox">
+                                            </div>
+                                            <div class="ml-3 text-md">
+                                                <label for="comments" class="medium">Conocer mi estado
+                                                    nutricional</label>
+                                            </div>
                                         </div>
                                         <div>
                                             <div class="flex items-start">
@@ -212,6 +235,7 @@
     </div>
 
     </div>
+
 </turbo-frame>
 
 

--- a/app/views/patients/expedients/habits.html.erb
+++ b/app/views/patients/expedients/habits.html.erb
@@ -42,6 +42,9 @@
                                     </div>
                                 </form>
                             </div>
+
+                           
+
                         </div>
                     </div>
                 </div> <!-- fin card información personal-->
@@ -602,6 +605,12 @@
 
             </div>
 
+                                                                <input x-ref="search" x-show="open" x-model="search"
+                                                                    @keydown.enter.stop.prevent="selectOption()"
+                                                                    @keydown.arrow-up.prevent="focusPreviousOption()"
+                                                                    @keydown.arrow-down.prevent="focusNextOption()"
+                                                                    type="search"
+                                                                    class="w-full h-full form-control focus:outline-none" />
 
             <!-- Relación con los alimentos-->
             <div class="bg-gray-100 w-full px-6 py-5">

--- a/app/views/patients/expedients/history.html.erb
+++ b/app/views/patients/expedients/history.html.erb
@@ -224,9 +224,6 @@
                                             </div>
                                         </div>
 
-
-
-
                                         </fieldset>
                                         <div class="col-span-6 sm:col-span-4 mt-8">
                                             <label for="motive" class="text-sm">Otro trastorno gastrointestinal</label>
@@ -298,7 +295,11 @@
                                     </div>
 
 
-                                </div>
+                                                </div>
+                                            </div>
+
+
+                                        </div>
                             </form>
                         </div>
                     </div>
@@ -353,6 +354,13 @@
                                             <!--Fin Select-->
                                             </div>
 
+                                                    <div x-show="! Object.keys(options).length"
+                                                        x-text="emptyOptionsMessage"
+                                                        class="px-3 py-2 text-gray-900 cursor-default select-none">
+                                                    </div>
+                                                </ul>
+                                            </div>
+                                        </div>
 
                                         </div>
                             </form>

--- a/app/views/patients/expedients/index.html.erb
+++ b/app/views/patients/expedients/index.html.erb
@@ -83,7 +83,7 @@
                                     <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
                                     <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
                                         aria-current="page" data-controller="operation-tabs"
-                                        data-operation-tabs-url-value="<%=expedients_general_path%>"
+                                        data-operation-tabs-url-value="<%=new_patients_general_path%>"
                                         data-operation-tabs-id-value="general"
                                         data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
                                         data-paint-active-tabs-target="option">
@@ -92,7 +92,7 @@
 
                                     <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
                                         aria-current="page" data-controller="operation-tabs"
-                                        data-operation-tabs-url-value="<%=expedients_history_path%>"
+                                        data-operation-tabs-url-value="<%=new_patients_historial_path%>"
                                         data-operation-tabs-id-value="history"
                                         data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
                                         data-paint-active-tabs-target="option">
@@ -101,7 +101,7 @@
 
                                     <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
                                         aria-current="page" data-controller="operation-tabs"
-                                        data-operation-tabs-url-value="<%=expedients_anthropometric_path%>"
+                                        data-operation-tabs-url-value="<%=new_patients_anthropometric_path%>"
                                         data-operation-tabs-id-value="anthropometric"
                                         data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
                                         data-paint-active-tabs-target="option">
@@ -110,7 +110,7 @@
 
                                     <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
                                         aria-current="page" data-controller="operation-tabs"
-                                        data-operation-tabs-url-value="<%=expedients_habits_path%>"
+                                        data-operation-tabs-url-value="<%=new_patients_habit_path%>"
                                         data-operation-tabs-id-value="habits"
                                         data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
                                         data-paint-active-tabs-target="option">
@@ -119,7 +119,7 @@
 
                                     <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
                                         aria-current="page" data-controller="operation-tabs"
-                                        data-operation-tabs-url-value="<%=expedients_physical_activity_path%>"
+                                        data-operation-tabs-url-value="<%=new_patients_physical_activity_path%>"
                                         data-operation-tabs-id-value="physical_activity"
                                         data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
                                         data-paint-active-tabs-target="option">
@@ -128,7 +128,7 @@
 
                                     <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
                                         aria-current="page" data-controller="operation-tabs"
-                                        data-operation-tabs-url-value="<%=expedients_notes_path%>"
+                                        data-operation-tabs-url-value="<%=new_patients_note_path%>"
                                         data-operation-tabs-id-value="notes"
                                         data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
                                         data-paint-active-tabs-target="option">
@@ -147,105 +147,3 @@
                         </div>
 
                     </div>
-
-
-
-
-                    <script>
-                        function select(config) {
-                            return {
-                                data: config.data,
-
-                                emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-
-                                focusedOptionIndex: null,
-
-                                name: config.name,
-
-                                open: false,
-
-                                options: {},
-
-                                placeholder: config.placeholder ?? 'Select an option',
-
-                                search: '',
-
-                                value: config.value,
-
-                                closeListbox: function () {
-                                    this.open = false
-
-                                    this.focusedOptionIndex = null
-
-                                    this.search = ''
-                                },
-
-                                focusNextOption: function () {
-                                    if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-
-                                    if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-
-                                    this.focusedOptionIndex++
-
-                                    this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-                                        block: "center",
-                                    })
-                                },
-
-                                focusPreviousOption: function () {
-                                    if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-
-                                    if (this.focusedOptionIndex <= 0) return
-
-                                    this.focusedOptionIndex--
-
-                                    this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-                                        block: "center",
-                                    })
-                                },
-
-                                init: function () {
-                                    this.options = this.data
-
-                                    if (!(this.value in this.options)) this.value = null
-
-                                    this.$watch('search', ((value) => {
-                                        if (!this.open || !value) return this.options = this.data
-
-                                        this.options = Object.keys(this.data)
-                                            .filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-                                            .reduce((options, key) => {
-                                                options[key] = this.data[key]
-                                                return options
-                                            }, {})
-                                    }))
-                                },
-
-                                selectOption: function () {
-                                    if (!this.open) return this.toggleListboxVisibility()
-
-                                    this.value = Object.keys(this.options)[this.focusedOptionIndex]
-
-                                    this.closeListbox()
-                                },
-
-                                toggleListboxVisibility: function () {
-                                    if (this.open) return this.closeListbox()
-
-                                    this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-
-                                    if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-
-                                    this.open = true
-
-                                    this.$nextTick(() => {
-                                        this.$refs.search.focus()
-
-                                        this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-                                            block: "center"
-                                        })
-                                    })
-                                },
-                            }
-                        }
-                    </script>

--- a/app/views/patients/expedients/notes.html.erb
+++ b/app/views/patients/expedients/notes.html.erb
@@ -3,21 +3,205 @@
     <div class="border-t border-gray-200">
         <div class="mt-2 relative flex-1 overflow-y-auto">
             <!-- Replace with your content -->
-
             <div class="bg-gray-100 w-full px-6 py-5">
 
-                <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <!-- Inicia card Tipo de alimentación -->
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
                             <h3>Notas </h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
                             <div class="mt-3 md:mt-3 md:col-span-3">
 
-                                <div class="col-span-6 sm:col-span-4 mt-8">
-                                    <label for="notes" class="block text-sm font-medium text-gray-500">Notas del
-                                        paciente</label>
-                                    <textarea name="notes" autocomplete="notes"
-                                        class="mt-1 px-4 py-60 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md"></textarea>
+
+                                <div class="col-span-6 sm:col-span-4 mt-2">
+                                    <label for="notes"
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-sm">Sólo
+                                        tu puedes ver estas notas </label>
+                                    <span class="text-gray-500 ml-auto inline-block px-2 text-sm rounded-full">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                            viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                    </span>
+
+                                    <div class="flex justify-between">
+                                        <label for="allergies" class="block text-sm font-medium text-white">Agregar
+                                            nota</label>
+                                        <button type="button"
+                                            class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                            <!-- Heroicon name: outline/plus -->
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5"
+                                                fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                            </svg>
+                                            Agregar nota
+                                        </button>
+                                    </div>
+
+
+
+                                    <div class="bg-gray-50 shadow px-4 py-5 mt-4 sm:rounded-lg sm:p-6 ">
+
+                                        <!-- This example requires Tailwind CSS v2.0+ -->
+                                        <ul role="list"
+                                            class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        Lorem Ipsum is simply dummy text of the printing and
+                                                        typesetting industry. Lorem Ipsum has been the
+                                                        industry's standard dummy text ever since the 1500s,
+                                                        when an unknown printer took a galley of type and
+                                                        scrambled it to make a type specimen book.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">5 Oct
+                                                                2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4 ml-2">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        Contrary to popular belief, Lorem Ipsum is not
+                                                        simply random text. It has roots in a piece of
+                                                        classical Latin literature from 45 BC, making it
+                                                        over 2000 years old. Richard McClintock, a Latin
+                                                        professor at Hampden-Sydney College in Virginia.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">12
+                                                                Oct 2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        It has survived not only five centuries, but also
+                                                        the leap into electronic typesetting, remaining
+                                                        essentially unchanged. It was popularised in the
+                                                        1960s with the release of Letraset sheets containing
+                                                        Lorem Ipsum passages, and more recently with
+                                                        desktop.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">20
+                                                                Oct 2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4 ml-2">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        Lorem Ipsum is simply dummy text of the printing and
+                                                        typesetting industry. Lorem Ipsum has been the
+                                                        industry's standard dummy text ever since the 1500s,
+                                                        when an unknown printer took a galley of type and
+                                                        scrambled it to make a type specimen book.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">3 Nov
+                                                                2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+
+                                            <!-- More people... -->
+                                        </ul>
+
+
+
+                                    </div>
+
                                 </div>
 
 

--- a/app/views/patients/expedients/show.html.erb
+++ b/app/views/patients/expedients/show.html.erb
@@ -1,2 +1,149 @@
-<h1>Expedients#show</h1>
-<p>Find me in app/views/patients/expedients/show.html.erb</p>
+<!-- This example requires Tailwind CSS v2.0+ Comienza slide over-->
+<div x-data="{open: true}" class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog"
+    aria-modal="true">
+    <div class="absolute inset-0 overflow-hidden">
+        <!--
+         Background overlay, show/hide based on slide-over state.
+  
+        Entering: "ease-in-out duration-500"
+          From: "opacity-0"
+          To: "opacity-100"
+        Leaving: "ease-in-out duration-500"
+          From: "opacity-100"
+          To: "opacity-0"
+      -->
+        <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"
+            @click="open = false; setTimeout(() => open = true, 1000);">Cuerpo del Index</div>
+        <div x-show="open" class="fixed inset-y-0 right-0 pl-10 max-w-full flex"
+            x-transition:enter="transform transition ease-in-out duration-500"
+            x-transition:enter-start="translate-x-full" x-transition:enter-end="translate-x-0"
+            x-transition:leave="transform transition ease-in-out duration-500" x-transition:leave-start="translate-x-0"
+            x-transition:leave-end="translate-x-full">
+            <!--
+          Slide-over panel, show/hide based on slide-over state.
+  
+          Entering: "transform transition ease-in-out duration-500 sm:duration-700"
+            From: "translate-x-full"
+            To: "translate-x-0"
+          Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
+            From: "translate-x-0"
+            To: "translate-x-full"
+        -->
+            <div class="relative w-screen max-w-3xl">
+                <!--
+            Close button, show/hide based on slide-over state.
+  
+            Entering: "ease-in-out duration-500"
+              From: "opacity-0"
+              To: "opacity-100"
+            Leaving: "ease-in-out duration-500"
+              From: "opacity-100"
+              To: "opacity-0"
+          -->
+                <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
+                    <button @click="open = false; setTimeout(() => open = true, 1000);" aria-label="Close panel"
+                        class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
+                        <!-- Heroicon name: outline/x -->
+                        <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M6 18L18 6M6 6l12 12" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
+                    <div class="px-4 sm:px-6 mt-4">
+                        <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
+                            Expediente
+                        </h2>
+                        <div class="mt-5">
+                            <div class="sm:hidden">
+                                <label for="tabs" class="sr-only">Select a tab</label>
+                                <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
+                                <select id="tabs" name="tabs"
+                                    class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md "
+                                    onchange="javascript:location.href = this.value;">
+                                    <option>
+                                        Generales</option>
+
+                                    <option>Historial</option>
+
+                                    <option>Antropométrico</option>
+
+                                    <option>Hábitos</option>
+
+                                    <option>Actividad física</option>
+
+                                    <option>Notas</option>
+                                </select>
+                            </div>
+                            <div class="hidden sm:block">
+                                <nav data-controller="paint-active-tabs" class="flex space-x-4" aria-label="Tabs">
+                                    <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
+                                    <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
+                                        aria-current="page" data-controller="operation-tabs"
+                                        data-operation-tabs-url-value="<%=new_patients_general_path%>"
+                                        data-operation-tabs-id-value="general"
+                                        data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
+                                        data-paint-active-tabs-target="option">
+                                        Generales
+                                    </a>
+
+                                    <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
+                                        aria-current="page" data-controller="operation-tabs"
+                                        data-operation-tabs-url-value="<%=new_patients_historial_path%>"
+                                        data-operation-tabs-id-value="history"
+                                        data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
+                                        data-paint-active-tabs-target="option">
+                                        Historial
+                                    </a>
+
+                                    <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
+                                        aria-current="page" data-controller="operation-tabs"
+                                        data-operation-tabs-url-value="<%=new_patients_anthropometric_path%>"
+                                        data-operation-tabs-id-value="anthropometric"
+                                        data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
+                                        data-paint-active-tabs-target="option">
+                                        Antropométrico
+                                    </a>
+
+                                    <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
+                                        aria-current="page" data-controller="operation-tabs"
+                                        data-operation-tabs-url-value="<%=new_patients_habit_path%>"
+                                        data-operation-tabs-id-value="habits"
+                                        data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
+                                        data-paint-active-tabs-target="option">
+                                        Hábitos
+                                    </a>
+
+                                    <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
+                                        aria-current="page" data-controller="operation-tabs"
+                                        data-operation-tabs-url-value="<%=new_patients_physical_activity_path%>"
+                                        data-operation-tabs-id-value="physical_activity"
+                                        data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
+                                        data-paint-active-tabs-target="option">
+                                        Actividad física
+                                    </a>
+
+                                    <a class="bg-indigo-50 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md"
+                                        aria-current="page" data-controller="operation-tabs"
+                                        data-operation-tabs-url-value="<%=new_patients_note_path%>"
+                                        data-operation-tabs-id-value="notes"
+                                        data-action="click->operation-tabs#changeTab click->paint-active-tabs#selectTab"
+                                        data-paint-active-tabs-target="option">
+                                        Notas
+                                    </a>
+                                </nav>
+                            </div>
+                            <div class="border-t border-gray-200">
+                                <turbo-frame data-controller="operation-tabs-shower"
+                                    data-operation-tabs-shower-target="turboFrame"
+                                    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame"
+                                    id="expedients">
+                                    
+                                </turbo-frame>
+                            </div>
+                        </div>
+
+                    </div>

--- a/app/views/patients/generals/new.html.erb
+++ b/app/views/patients/generals/new.html.erb
@@ -1,441 +1,242 @@
-<div class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog" aria-modal="true">
-    <div class="absolute inset-0 overflow-hidden">
-      <!--
-        Background overlay, show/hide based on slide-over state.
-  
-        Entering: "ease-in-out duration-500"
-          From: "opacity-0"
-          To: "opacity-100"
-        Leaving: "ease-in-out duration-500"
-          From: "opacity-100"
-          To: "opacity-0"
-      -->
-        <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-        
-            <div class="fixed inset-y-0 right-0 pl-10 max-w-full flex">
-                <!--
-                Slide-over panel, show/hide based on slide-over state.
-        
-                Entering: "transform transition ease-in-out duration-500 sm:duration-700"
-                    From: "translate-x-full"
-                    To: "translate-x-0"
-                Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-                    From: "translate-x-0"
-                    To: "translate-x-full"
-                -->
-                <div class="relative w-screen max-w-3xl">
-                <!--
-                    Close button, show/hide based on slide-over state.
-        
-                    Entering: "ease-in-out duration-500"
-                    From: "opacity-0"
-                    To: "opacity-100"
-                    Leaving: "ease-in-out duration-500"
-                    From: "opacity-100"
-                    To: "opacity-0"
-                -->
-                <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
-                    <button type="button" class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
-                    <span class="sr-only">Close panel</span>
-                    <!-- Heroicon name: outline/x -->
-                    <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                    </button>
-                </div>
-        
-                <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
-                    <div class="px-4 sm:px-6 mt-4">
-                        <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
-                            Expediente
-                        </h2>
-                        <div class="mt-5">
-                            <div class="sm:hidden">
-                            <label for="tabs" class="sr-only">Select a tab</label>
-                            <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-                            <select id="tabs" name="tabs" class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md">
-                                <option selected>Generales</option>
-                        
-                                <option>Historial</option>
+<turbo-frame data-controller="operation-tabs-shower" data-operation-tabs-shower-target="turboFrame"
+    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame" id="general">
+    <div class="border-t border-gray-200">
+        <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
 
-                                                        <option >Antropométrico</option>
-                        
-                                <option>Hábitos</option>
-                        
-                                <option>Actividad física</option>
+            <div class="mt-2 relative flex-1 overflow-y-auto">
+                <!-- Replace with your content -->
+                <div class="bg-gray-100 w-full px-6 py-5">
+                    <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                        <div class="md:grid md:grid-cols-3 md:gap-6">
+                            <div class="md:col-span-3">
+                                <h3>Información Personal</h3>
+                                <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
 
-                                <option>Notas</option>
-                            </select>
-                            </div>
-                            <div class="hidden sm:block">
-                            <nav class="flex space-x-4" aria-label="Tabs">
-                                <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
-                                <a href="general" class="bg-indigo-100 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md" aria-current="page">
-                                Generales
-                                </a>
+                                <div class="mt-5 md:mt-5 md:col-span-3">
+                                    <form action="#" method="POST">
+                                        <div class="grid grid-cols-6 gap-6">
+                                            <div class="col-span-6 sm:col-span-6 mt-4">
+                                                <label for="motive" class="text-sm">Nombre(s)</label>
+                                                <input type="text" name="motive" id="motive" autocomplete="motive"
+                                                    class="placeholder">
+                                            </div>
 
-                                <a href="history" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                                Historial
-                                </a>
+                                            <div class="col-span-6 sm:col-span-3">
+                                                <label for="first-name" class="text-sm">Apellido Paterno</label>
+                                                <input type="text" name="first-name" id="first-name"
+                                                    autocomplete="given-name" class="placeholder">
+                                            </div>
 
-                                                        <a href="anthropometric" class=" text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                                Antropométrico
-                                </a>
-                        
-                                <a href="habits" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                                Hábitos
-                                </a>
+                                            <div class="col-span-6 sm:col-span-3">
+                                                <label for="last-name" class="text-sm">Apellido Materno</label>
+                                                <input type="text" name="last-name" id="last-name"
+                                                    autocomplete="family-name" class="placeholder">
+                                            </div>
 
-                                <a href="physical_activity" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                                Actividad física
-                                </a>
-                        
-                                <a href="notes" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                                Notas
-                                </a>
-                            </nav>
-                            </div>
-                        </div>
-        
-                    </div>
-                    <div class="mt-2 relative flex-1 overflow-y-auto">
-                    <!-- Replace with your content -->
+                                            <div class="col-span-6 sm:col-span-4">
+                                                <label for="email-address" class="text-sm">Correo
+                                                    electrónico</label>
+                                                <input type="text" name="email-address" id="email-address"
+                                                    autocomplete="email" class="placeholder">
+                                            </div>
 
-                    <%= form_for(@patient, url: patients_generals_path) do |form| %>
-                        <div class="bg-gray-100 w-full px-6 py-5">
-                            <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-                                <div class="md:grid md:grid-cols-3 md:gap-6">
-                                    <div class="md:col-span-3">
-                                        <h3>Información Personal</h3>
-                                        <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                                    
-                                        <div class="mt-5 md:mt-5 md:col-span-3">
-                                            
-                                                <div class="grid grid-cols-6 gap-6">
-                                                    <div class="col-span-6 sm:col-span-6 mt-4">
-                                                        
-                                                        <%=form.label :name,'Nombre(s)', class: "text-sm"%> 
-                                                        <%=form.text_field :name, class: "placeholder"%> 
+                                            <div class="col-span-6 sm:col-span-2">
+                                                <label for="phone" class="text-sm">Celular</label>
+                                                <input type="text" name="phone" id="phone" autocomplete="phone"
+                                                    class="placeholder">
+                                            </div>
+
+                                            <div class="col-span-6 sm:col-span-2">
+                                                <label for="birth-date" class="text-sm">Fecha de
+                                                    nacimiento</label>
+                                                <input type="date" placeholder="DD/MM/YY" name="birth-date"
+                                                    id="irth-date" autocomplete="irth-date" class="placeholder">
+                                            </div>
+
+                                            <div class="col-span-6 sm:col-span-2">
+                                                <label for="age" class="text-sm">Edad</label>
+                                                <h3
+                                                    class="mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md">
+                                                    27
+                                                </h3>
+                                            </div>
+
+                                            <div class="col-span-6 sm:col-span-3">
+                                                <div>
+                                                    <div>
+                                                        <label for="genero" class="block text-sm ">Género</label>
+                                                        <select id="genero" name="genero" placeholder="Elige un género" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                            <option disabled selected>Elige un género</option>
+                                                            <option>Masculino</option>
+                                                            <option>Femenino</option>
+                                                        </select>
+                                                        </div>     
                                                     </div>
-
-                                                    <div class="col-span-6 sm:col-span-3">
-                                                        
-                                                        <%=form.label :last_name,'Apellido Paterno', class: "text-sm"%> 
-                                                        <%=form.text_field :last_name, class: "placeholder"%> 
-                                                    </div>
-                                        
-                                                    <div class="col-span-6 sm:col-span-3">
-                                                        
-                                                        <%=form.label :mothers_last_name,'Apellido Materno', class: "text-sm"%> 
-                                                        <%=form.text_field :mothers_last_name, class: "placeholder"%> 
-                                                    </div>
-                                        
-                                                    <div class="col-span-6 sm:col-span-4">
-                                                        
-                                                        <%=form.label :email, 'Correo electrónico',class: "text-sm" %>
-                                                        <%=form.email_field :email, class: "placeholder" %>
-                                                    </div>
-
-                                                    <div class="col-span-6 sm:col-span-2">
-                                                        
-                                                        <%=form.label :phone, 'Celular', class: "text-sm" %>
-                                                        <%=form.number_field :phone, class: "placeholder" %>
-                                                    </div>
-
-                                                    <div class="col-span-6 sm:col-span-2">
-                                                        
-                                                        <%=form.label :birth_date, 'Fecha de nacimiento', clas: "text-sm" %>
-                                                        <%=form.date_field :birth_date, class: "placeholder" %>
-                                                    </div>
-
-                                                    <div class="col-span-6 sm:col-span-2">
-                                                        <label for="age" class="text-sm">Edad</label>
-                                                        <h3 class="mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md">
-                                                            27
-                                                        </h3>
-                                                        <%=form.label :age, 'Edad', class: "text-sm" %> 
-                                                        <%=form.text_field :age, class: "mt-1 p-2 h-11 border bg-gray-50 block w-full sm:text-md text-gray-400 border-gray-300 rounded-md"%> 
-                                                    </div>
-
-                                                    <div class="col-span-6 sm:col-span-3">
-                                                        <div>
-                                                        <label id="listbox-label-gener" class="text-sm">
-                                                            Género
-                                                        </label>
-                                                        <div class="max-w-xs mt-1">
-                                                            <div
-                                                                    x-data="select({ data: { m: 'Masculino', f: 'Femenino'}, emptyOptionsMessage: 'No se ha seleccionado un género.', name: 'genero', placeholder: 'Elige un genero' })"
-                                                                    x-init="init()"
-                                                                    @click.away="closeListbox()"
-                                                                    @keydown.escape="closeListbox()"
-                                                                    class="relative"
-                                                            >
-                                                                    <span class="inline-block w-full rounded-md shadow-sm">
-                                                                        <button type="button"
-                                                                                x-ref="button"
-                                                                                @click="toggleListboxVisibility()"
-                                                                                :aria-expanded="open"
-                                                                                aria-haspopup="listbox"
-                                                                                class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-                                                                        >
-                                                                                <span
-                                                                                        x-show="! open"
-                                                                                        x-text="value in options ? options[value] : placeholder"
-                                                                                        :class="{ 'text-gray-500': ! (value in options) }"
-                                                                                        class="block truncate"
-                                                                                ></span>
-                                                                                
-                                                                                <input
-                                                                                        x-ref="search"
-                                                                                        x-show="open"
-                                                                                        x-model="search"
-                                                                                        @keydown.enter.stop.prevent="selectOption()"
-                                                                                        @keydown.arrow-up.prevent="focusPreviousOption()"
-                                                                                        @keydown.arrow-down.prevent="focusNextOption()"
-                                                                                        type="search"
-                                                                                        class="w-full h-full form-control focus:outline-none"
-                                                                                />
-                                                    
-                                                                                <span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-                                                                                    <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-                                                                                        <path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-                                                                                            stroke-linejoin="round"></path>
-                                                                                    </svg>
-                                                                                </span>
-                                                                        </button>
-                                                                    </span>
-                                                    
-                                                                <div
-                                                                        x-show="open"
-                                                                        x-transition:leave="transition ease-in duration-100"
-                                                                        x-transition:leave-start="opacity-100"
-                                                                        x-transition:leave-end="opacity-0"
-                                                                        x-cloak
-                                                                        class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-                                                                >
-                                                                    <ul
-                                                                            x-ref="listbox"
-                                                                            @keydown.enter.stop.prevent="selectOption()"
-                                                                            @keydown.arrow-up.prevent="focusPreviousOption()"
-                                                                            @keydown.arrow-down.prevent="focusNextOption()"
-                                                                            role="listbox"
-                                                                            :aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-                                                                            tabindex="-1"
-                                                                            class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-                                                                    >
-                                                                        <template x-for="(key, index) in Object.keys(options)" :key="index">
-                                                                            <li
-                                                                                    :id="name + 'Option' + focusedOptionIndex"
-                                                                                    @click="selectOption()"
-                                                                                    @mouseenter="focusedOptionIndex = index"
-                                                                                    @mouseleave="focusedOptionIndex = null"
-                                                                                    role="option"
-                                                                                    :aria-selected="focusedOptionIndex === index"
-                                                                                    :class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-                                                                                    class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-                                                                            >
-                                                                                    <span x-text="Object.values(options)[index]"
-                                                                                        :class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-                                                                                        class="block font-normal truncate"
-                                                                                    ></span>
-                                                    
-                                                                                <span
-                                                                                        x-show="key === value"
-                                                                                        :class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-                                                                                        class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-                                                                                >
-                                                                                        <svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-                                                                                            <path fill-rule="evenodd"
-                                                                                                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                                                                                                clip-rule="evenodd"/>
-                                                                                        </svg>
-                                                                                    </span>
-                                                                            </li>
-                                                                        </template>
-                                                    
-                                                                        <div
-                                                                                x-show="! Object.keys(options).length"
-                                                                                x-text="emptyOptionsMessage"
-                                                                                class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-                                                                    </ul>
-                                                                </div>
-                                                            </div>
-                                                    
-                                                            <script>
-                                                                function select(config) {
-                                                                    return {
-                                                                        data: config.data,
-                                                    
-                                                                        emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-                                                    
-                                                                        focusedOptionIndex: null,
-                                                    
-                                                                        name: config.name,
-                                                    
-                                                                        open: false,
-                                                    
-                                                                        options: {},
-                                                    
-                                                                        placeholder: config.placeholder ?? 'Select an option',
-                                                    
-                                                                        search: '',
-                                                    
-                                                                        value: config.value,
-                                                    
-                                                                        closeListbox: function () {
-                                                                            this.open = false
-                                                    
-                                                                            this.focusedOptionIndex = null
-                                                    
-                                                                            this.search = ''
-                                                                        },
-                                                    
-                                                                        focusNextOption: function () {
-                                                                            if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-                                                    
-                                                                            if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-                                                    
-                                                                            this.focusedOptionIndex++
-                                                    
-                                                                            this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-                                                                                block: "center",
-                                                                            })
-                                                                        },
-                                                    
-                                                                        focusPreviousOption: function () {
-                                                                            if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-                                                    
-                                                                            if (this.focusedOptionIndex <= 0) return
-                                                    
-                                                                            this.focusedOptionIndex--
-                                                    
-                                                                            this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-                                                                                block: "center",
-                                                                            })
-                                                                        },
-                                                    
-                                                                        init: function () {
-                                                                            this.options = this.data
-                                                    
-                                                                            if (!(this.value in this.options)) this.value = null
-                                                    
-                                                                            this.$watch('search', ((value) => {
-                                                                                if (!this.open || !value) return this.options = this.data
-                                                    
-                                                                                this.options = Object.keys(this.data)
-                                                                                    .filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-                                                                                    .reduce((options, key) => {
-                                                                                        options[key] = this.data[key]
-                                                                                        return options
-                                                                                    }, {})
-                                                                            }))
-                                                                        },
-                                                    
-                                                                        selectOption: function () {
-                                                                            if (!this.open) return this.toggleListboxVisibility()
-                                                    
-                                                                            this.value = Object.keys(this.options)[this.focusedOptionIndex]
-                                                    
-                                                                            this.closeListbox()
-                                                                        },
-                                                    
-                                                                        toggleListboxVisibility: function () {
-                                                                            if (this.open) return this.closeListbox()
-                                                    
-                                                                            this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-                                                    
-                                                                            if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-                                                    
-                                                                            this.open = true
-                                                    
-                                                                            this.$nextTick(() => {
-                                                                                this.$refs.search.focus()
-                                                    
-                                                                                this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-                                                                                    block: "center"
-                                                                                })
-                                                                            })
-                                                                        },
-                                                                    }
-                                                                }
-                                                            </script>
-                                                        </div>
-                                                        <%= form.label :gender, 'Género', class: "text-sm" %> 
-                                                        <%= form.select :gender, ["Masculino", "Femenino"],  placeholder: "Elige un género" %>
-                                                    </div>
-                                                    <br>
-                                                    <div class="col-span-6 sm:col-span-4">
-                                                        
-                                                        <%=form.label :occupation, 'Ocupación', class: "text-sm"%> 
-                                                        <%=form.text_field :occupation, class: "placeholder"%> 
-                                                    </div>
+                                                <br>
+                                                <div class="col-span-6 sm:col-span-4">
+                                                    <label for="occupation" class="text-sm">Ocupación</label>
+                                                    <input type="text" name="occupation" id="occupation"
+                                                        autocomplete="occupation" class="placeholder">
                                                 </div>
-                                            
-                                        </div>
-                                    </div>
+                                            </div>
+                                    </form>
                                 </div>
-                            </div> <!-- fin card información personal-->
+                            </div>
                         </div>
-
-                        <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
-                            <div class="md:grid md:grid-cols-3 md:gap-6">
-                              <div class="md:col-span-3">
-                                <h3>Motivo de consulta</h3>
-                                  <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                                  <div class="mt-3 md:mt-3 md:col-span-3">
-
-                                    <fieldset>
-                                      <legend class="text-base font-medium text-gray-900"></legend>
-                                      <div class="mt-4 space-y-4">
-
-                                          <%- ['Conocer mi estado nutricional', 'Tener un estilo de vida saludable', 'Mejorar mi composición corporal',
-                                               'Perder peso', 'Aumentar de peso','Mantener mi condición física', 'Control de enfermedad',
-                                               'Embarazo/ Lactancia', 'Deportivo'].each do | objectives |%>
-                                          <div class="flex items-start">      
+                    </div> <!-- fin card información personal-->
+                </div>
+                <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Motivo de consulta</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+                            <div class="mt-3 md:mt-3 md:col-span-3">
+                                <fieldset>
+                                    <legend class="text-base font-medium text-gray-900"></legend>
+                                    <div class="mt-4 space-y-4">
+                                        <div class="flex items-start">
                                             <div class="h-5 flex items-center">
-                                              <%= check_box_tag("patient[objectives][]", objectives, @patient.objectives.include?(objectives), id: "objectives_#{objectives}")%>
+                                                <input id="comments" name="comments" type="checkbox" class="checkbox">
                                             </div>
                                             <div class="ml-3 text-md">
-                                              <label for="#{objectives}" class="medium"><%= objectives %></label>
+                                                <label for="comments" class="medium">Conocer mi estado
+                                                    nutricional</label>
                                             </div>
-                                          
-                                          </div>
-                                          <% end %>
-                                        
-                                      </div>
-                                    </fieldset>
-
-                                        <div class="col-span-6 sm:col-span-4 mt-8">
-                                            <label for="motive" class="text-sm">Otro motivo</label>
-                                            <input type="text" name="motive" id="motive" autocomplete="motive" class="placeholder">
                                         </div>
-                                    </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="candidates" name="candidates" type="checkbox"
+                                                        class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="candidates" class="medium">Tener un estilo de
+                                                        vida saludable</label>
+                                                </div>
+                                            </div>
+                                    </form>
                                 </div>
                             </div>
                         </div>
-                        <div>
-        <%=form.submit%>
-    </div> <!-- fin card Motivo de consulta-->
-                        
-                    <%end %>
-
-
-
-
-
-
-                    </div>
-                    
-                    <!-- /End replace -->
-                    </div>
+                    </div> <!-- fin card información personal-->
                 </div>
-                
-                </div>
-                
+                <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Motivo de consulta</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+                            <div class="mt-3 md:mt-3 md:col-span-3">
+                                <fieldset>
+                                    <legend class="text-base font-medium text-gray-900"></legend>
+                                    <div class="mt-4 space-y-4">
+                                        <div class="flex items-start">
+                                            <div class="h-5 flex items-center">
+                                                <input id="comments" name="comments" type="checkbox" class="checkbox">
+                                            </div>
+                                            <div class="ml-3 text-md">
+                                                <label for="comments" class="medium">Conocer mi estado
+                                                    nutricional</label>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Mejorar mi composición
+                                                        corporal</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Perder peso</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Aumentar de peso</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Mantener mi condición
+                                                        física</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Control de enfermedad
+                                                    </label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Embarazo/ Lactancia
+                                                    </label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Deportivo</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                                <div class="col-span-6 sm:col-span-4 mt-8">
+                                    <label for="motive" class="text-sm">Otro motivo</label>
+                                    <input type="text" name="motive" id="motive" autocomplete="motive"
+                                        class="placeholder">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin card Motivo de consulta-->
+
             </div>
-            
-        
-        
+
+            <!-- /End replace -->
+        </div>
     </div>
-  </div>
-  
+    </div>
+    </div>
+    </div>
+    </div>
+
+    </div>
+
+</turbo-frame>
+
+
+

--- a/app/views/patients/habits/new.html.erb
+++ b/app/views/patients/habits/new.html.erb
@@ -1,335 +1,50 @@
-<div class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog" aria-modal="true">
-    <div class="absolute inset-0 overflow-hidden">
-      <!--
-        Background overlay, show/hide based on slide-over state.
-  
-        Entering: "ease-in-out duration-500"
-          From: "opacity-0"
-          To: "opacity-100"
-        Leaving: "ease-in-out duration-500"
-          From: "opacity-100"
-          To: "opacity-0"
-      -->
-      <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-      <div class="fixed inset-y-0 right-0 pl-10 max-w-full flex">
-        <!--
-          Slide-over panel, show/hide based on slide-over state.
-  
-          Entering: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-full"
-            To: "translate-x-0"
-          Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-0"
-            To: "translate-x-full"
-        -->
-        <div class="relative w-screen max-w-3xl">
-          <!--
-            Close button, show/hide based on slide-over state.
-  
-            Entering: "ease-in-out duration-500"
-              From: "opacity-0"
-              To: "opacity-100"
-            Leaving: "ease-in-out duration-500"
-              From: "opacity-100"
-              To: "opacity-0"
-          -->
-          <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
-            <button type="button" class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
-              <span class="sr-only">Close panel</span>
-              <!-- Heroicon name: outline/x -->
-              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-
-  
-          <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
-            <div class="px-4 sm:px-6 mt-4">
-                <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
-                    Expediente
-                </h2>
-                <div class="mt-5">
-                    <div class="sm:hidden">
-                    <label for="tabs" class="sr-only">Select a tab</label>
-                    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-                    <select id="tabs" name="tabs" class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md">
-                        <option>Generales</option>
-                
-                        <option>Historial</option>
-
-												<option >Antropométrico</option>
-                
-                        <option selected>Hábitos</option>
-                
-                        <option>Actividad física</option>
-
-                        <option>Notas</option>
-                    </select>
-                    </div>
-                    <div class="hidden sm:block">
-                    <nav class="flex space-x-4" aria-label="Tabs">
-                        <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
-                        <a href="general" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Generales
-                        </a>
-
-                        <a href="history" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Historial
-                        </a>
-
-												<a href="anthropometric" class=" text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Antropométrico
-                        </a>
-
-                        <a href="habits" class="bg-indigo-100 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md" aria-current="page">
-                        Hábitos
-                        </a>
-
-                        <a href="physical_activity" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Actividad física
-                        </a>
-                
-                        <a href="notes" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Notas
-                        </a>
-                    </nav>
-                    </div>
-                </div>
-  
-            </div>
-            <div class="mt-2 relative flex-1 overflow-y-auto">
-              <!-- Replace with your content --> 
+<turbo-frame turbo-frame data-controller="operation-tabs-shower" data-operation-tabs-shower-target="turboFrame"
+    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame" id="habits">
+    <div class="border-t border-gray-200">
+        <div class="mt-2 relative flex-1 overflow-y-auto">
+            <!-- Replace with your content -->
             <div class="bg-gray-100 w-full px-6 py-5">
-                
-                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6"> <!-- Inicia card Tipo de alimentación --> 
+
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <!-- Inicia card Tipo de alimentación -->
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
                             <h3>Tipo de alimentación</h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                        
+
                             <div class="mt-5 md:mt-5 md:col-span-3">
                                 <form action="#" method="POST">
                                     <div class="grid grid-cols-6 gap-6">
 
-
-                                        <div class="col-span-4 sm:col-span-2 mt-1">
-
-                                          <div>
-																						<label id="listbox-label-alimentation" class="text-sm">
-																								Tipo de alimentación
-																						</label>
-																						<div class="max-w-screen-2xl mt-1">
-																								<div
-																												x-data="select({ data: { regular: 'Regular', vegetariana: 'Vegetariana', vegana: 'Vegana', pescetariana: 'Pescetariana'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'Elige una opción' })"
-																												x-init="init()"
-																												@click.away="closeListbox()"
-																												@keydown.escape="closeListbox()"
-																												class="relative"
-																								>
-																												<span class="inline-block w-full rounded-md shadow-sm">
-																															<button type="button"
-																																			x-ref="button"
-																																			@click="toggleListboxVisibility()"
-																																			:aria-expanded="open"
-																																			aria-haspopup="listbox"
-																																			class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																															>
-																																		<span
-																																						x-show="! open"
-																																						x-text="value in options ? options[value] : placeholder"
-																																						:class="{ 'text-gray-500': ! (value in options) }"
-																																						class="block truncate"
-																																		></span>
-																				
-																																		<input
-																																						x-ref="search"
-																																						x-show="open"
-																																						x-model="search"
-																																						@keydown.enter.stop.prevent="selectOption()"
-																																						@keydown.arrow-up.prevent="focusPreviousOption()"
-																																						@keydown.arrow-down.prevent="focusNextOption()"
-																																						type="search"
-																																						class="w-full h-full form-control focus:outline-none"
-																																		/>
-																				
-																																		<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																				<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																						<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																									stroke-linejoin="round"></path>
-																																				</svg>
-																																		</span>
-																															</button>
-																												</span>
-																				
-																										<div
-																														x-show="open"
-																														x-transition:leave="transition ease-in duration-100"
-																														x-transition:leave-start="opacity-100"
-																														x-transition:leave-end="opacity-0"
-																														x-cloak
-																														class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																										>
-																												<ul
-																																x-ref="listbox"
-																																@keydown.enter.stop.prevent="selectOption()"
-																																@keydown.arrow-up.prevent="focusPreviousOption()"
-																																@keydown.arrow-down.prevent="focusNextOption()"
-																																role="listbox"
-																																:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																tabindex="-1"
-																																class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																												>
-																														<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																<li
-																																				:id="name + 'Option' + focusedOptionIndex"
-																																				@click="selectOption()"
-																																				@mouseenter="focusedOptionIndex = index"
-																																				@mouseleave="focusedOptionIndex = null"
-																																				role="option"
-																																				:aria-selected="focusedOptionIndex === index"
-																																				:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																				class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																>
-																																				<span x-text="Object.values(options)[index]"
-																																							:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																							class="block font-normal truncate"
-																																				></span>
-																				
-																																		<span
-																																						x-show="key === value"
-																																						:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																						class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																		>
-																																						<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																								<path fill-rule="evenodd"
-																																											d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																											clip-rule="evenodd"/>
-																																						</svg>
-																																				</span>
-																																</li>
-																														</template>
-																				
-																														<div
-																																		x-show="! Object.keys(options).length"
-																																		x-text="emptyOptionsMessage"
-																																		class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																												</ul>
-																										</div>
-																								</div>
-																				
-																								<script>
-																										function select(config) {
-																												return {
-																														data: config.data,
-																				
-																														emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																				
-																														focusedOptionIndex: null,
-																				
-																														name: config.name,
-																				
-																														open: false,
-																				
-																														options: {},
-																				
-																														placeholder: config.placeholder ?? 'Select an option',
-																				
-																														search: '',
-																				
-																														value: config.value,
-																				
-																														closeListbox: function () {
-																																this.open = false
-																				
-																																this.focusedOptionIndex = null
-																				
-																																this.search = ''
-																														},
-																				
-																														focusNextOption: function () {
-																																if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																				
-																																if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																				
-																																this.focusedOptionIndex++
-																				
-																																this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																		block: "center",
-																																})
-																														},
-																				
-																														focusPreviousOption: function () {
-																																if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																				
-																																if (this.focusedOptionIndex <= 0) return
-																				
-																																this.focusedOptionIndex--
-																				
-																																this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																		block: "center",
-																																})
-																														},
-																				
-																														init: function () {
-																																this.options = this.data
-																				
-																																if (!(this.value in this.options)) this.value = null
-																				
-																																this.$watch('search', ((value) => {
-																																		if (!this.open || !value) return this.options = this.data
-																				
-																																		this.options = Object.keys(this.data)
-																																				.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																				.reduce((options, key) => {
-																																						options[key] = this.data[key]
-																																						return options
-																																				}, {})
-																																}))
-																														},
-																				
-																														selectOption: function () {
-																																if (!this.open) return this.toggleListboxVisibility()
-																				
-																																this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																				
-																																this.closeListbox()
-																														},
-																				
-																														toggleListboxVisibility: function () {
-																																if (this.open) return this.closeListbox()
-																				
-																																this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																				
-																																if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																				
-																																this.open = true
-																				
-																																this.$nextTick(() => {
-																																		this.$refs.search.focus()
-																				
-																																		this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																				block: "center"
-																																		})
-																																})
-																														},
-																												}
-																										}
-																								</script>
-																						</div>
-																				</div>
-																					<!--Fin select-->
+                                        <div class="col-span-4 sm:col-span-2 mt-2 ">
+                                            <!--Select-->
+                                            <div class="col-span-6 sm:col-span-6 mt-8">
+                                                    <label for="nivel_de_actividad_fisica" class="block text-sm">Tipo de alimentación</label>
+                                                    <select id="nivel_de_actividad_fisica" name="nivel_de_actividad_fisica" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Regular</option>
+                                                        <option>Vegetariana</option>
+                                                        <option>Vegana</option>
+                                                        <option>Pescetariana</option>
+                                                    </select>
+                                            </div>
+                                            <!--Fin Select-->
                                         </div>
 
                                         <div class="col-span-6 sm:col-span-4">
-                                          <label for="first-name" class="text-sm">Otro tipo</label>
-                                          <input type="text" name="first-name" id="first-name" autocomplete="given-name" class="placeholder" placeholder="Especificar otro tipo de alimentación">
+                                            <label for="first-name" class="text-sm">Otro tipo</label>
+                                            <input type="text" name="first-name" id="first-name"
+                                                autocomplete="given-name" class="placeholder"
+                                                placeholder="Especificar otro tipo de alimentación">
                                         </div>
 
-                                        
+
                                     </div>
                                 </form>
                             </div>
+
+                           
+
                         </div>
                     </div>
                 </div> <!-- fin card información personal-->
@@ -337,117 +52,159 @@
                 <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
-                            <h3 >Preferencias y exclusiones de alimentos</h3>
+                            <h3>Preferencias y exclusiones de alimentos</h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                            
-                            <div class="mt-3 md:mt-3 md:col-span-3">
+
+                            <div class="mt-3 md:mt-3 md:col-span-3" data-controller="modal">
+                                <div data-modal-target="modal"><!-- Asignación del Modal -->
+                                    <%= render 'common/modals/preferences'%>
+                                </div>
                                 <div class="flex justify-between">
-                                    <label for="allergies" class="text-sm">Alergias e intolerancias</label> 
-                                    <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                    <label for="allergies" class="text-sm">Alergias e intolerancias</label>
+                                    <button type="button" data-action="modal#show"
+                                        class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                                         <!-- Heroicon name: outline/plus -->
-                                        <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                            viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
                                         </svg>
                                         Agregar
                                     </button>
                                 </div>
                                 <div class="mt-0">
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
                                         Nuez
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
 
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
                                         Lacteos
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
                                 </div>
                             </div>
 
-                            <div class="mt-4 md:mt-6 md:col-span-3">
+                            <div class="mt-4 md:mt-6 md:col-span-3" data-controller="modal">
+                                <div data-modal-target="modal">
+                                    <%= render 'common/modals/preferences'%>
+                                </div>
                                 <div class="flex justify-between">
-                                    <label for="allergies" class="text-sm">Alimentos que no consume</label> 
-                                    <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                      <!-- Heroicon name: outline/plus -->
-                                      <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                                      </svg>
-                                      Agregar
-                                  </button>
+                                    <label for="allergies" class="text-sm">Alimentos que no consume</label>
+                                    <button type="button" data-action="modal#show"
+                                        class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                        <!-- Heroicon name: outline/plus -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                            viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                        </svg>
+                                        Agregar
+                                    </button>
                                 </div>
                                 <div class="mt-0">
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
                                         Pollo
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
 
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
                                         Glúten
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
 
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-yellow-100 text-yellow-800">
                                         Origen animal
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-yellow-500 hover:bg-yellow-200 hover:text-yellow-600 focus:outline-none focus:bg-yellow-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
                                 </div>
                             </div>
 
-                            <div class="mt-4 md:mt-6 md:col-span-3">
+                            <div class="mt-4 md:mt-6 md:col-span-3" data-controller="modal">
+                                <div data-modal-target="modal">
+                                    <%= render 'common/modals/preferences'%>
+                                </div>
                                 <div class="flex justify-between">
-                                    <label for="allergies" class="text-sm">Alimentos preferidos</label> 
-                                    <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                      <!-- Heroicon name: outline/plus -->
-                                      <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                                      </svg>
-                                      Agregar
-                                  </button>
+                                    <label for="allergies" class="text-sm">Alimentos preferidos</label>
+                                    <button type="button" data-action="modal#show"
+                                        class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                        <!-- Heroicon name: outline/plus -->
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                            viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                        </svg>
+                                        Agregar
+                                    </button>
                                 </div>
                                 <div class="mt-0">
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-purple-100 text-purple-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-purple-100 text-purple-800">
                                         Soya texturizada
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-purple-500 hover:bg-purple-200 hover:text-purple-600 focus:outline-none focus:bg-purple-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-purple-500 hover:bg-purple-200 hover:text-purple-600 focus:outline-none focus:bg-purple-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
 
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-purple-100 text-purple-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-purple-100 text-purple-800">
                                         Garbanzo
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-purple-500 hover:bg-purple-200 hover:text-purple-600 focus:outline-none focus:bg-purple-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-purple-500 hover:bg-purple-200 hover:text-purple-600 focus:outline-none focus:bg-purple-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
 
-                                    <span class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-purple-100 text-purple-800">
+                                    <span
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-md font-medium bg-purple-100 text-purple-800">
                                         Pan integral
-                                        <button type="button" class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-purple-500 hover:bg-purple-200 hover:text-purple-600 focus:outline-none focus:bg-purple-500 focus:text-white">
-                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none" viewBox="0 0 8 8">
-                                            <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
+                                        <button type="button"
+                                            class="flex-shrink-0 mt-0.5 ml-2 h-4 w-4 rounded-full inline-flex items-center justify-center text-purple-500 hover:bg-purple-200 hover:text-purple-600 focus:outline-none focus:bg-purple-500 focus:text-white">
+                                            <svg class="h-2.5 w-2.5" stroke="currentColor" fill="none"
+                                                viewBox="0 0 8 8">
+                                                <path stroke-linecap="round" stroke-width="1.5" d="M1 1l6 6m0-6L1 7" />
                                             </svg>
                                         </button>
                                     </span>
@@ -460,957 +217,199 @@
                 </div> <!-- fin card preferencias y exclusiones-->
 
                 <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
-                  <div class="md:grid md:grid-cols-3 md:gap-6">
-                      <div class="md:col-span-3">
-                          <h3 >Suplementos</h3>
-                          <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                          <div class="mt-3 md:mt-3 md:col-span-3">
-                              <fieldset>
-                                  <legend class="text-base font-medium text-gray-900"></legend>
-                                  <div class="mt-4 grid grid-cols-4 gap-2">
-                                      <div class="flex items-start">
-                                      <div class="h-5 flex items-center">
-                                          <input id="comments" name="comments" type="checkbox" class="checkbox">
-                                      </div>
-                                      <div class="ml-3 text-md">
-                                          <label for="comments" class="medium">Ninguno</label>
-                                      </div>
-                                      </div>
-                                      <div>
-                                      <div class="flex items-start">
-                                          <div class="h-5 flex items-center">
-                                          <input id="candidates" name="candidates" type="checkbox" class="checkbox">
-                                          </div>
-                                          <div class="ml-3 text-md">
-                                          <label for="candidates" class="medium">Proteína</label>
-                                          </div>
-                                      </div>
-                                      </div>
-                                      <div>
-                                      <div class="flex items-start">
-                                          <div class="h-5 flex items-center">
-                                          <input id="offers" name="offers" type="checkbox" class="checkbox">
-                                          </div>
-                                          <div class="ml-3 text-md">
-                                          <label for="offers" class="medium">Multivitamínico</label>
-                                          </div>
-                                      </div>
-                                      </div>
-                                      <div>
-                                          <div class="flex items-start">
-                                              <div class="h-5 flex items-center">
-                                              <input id="offers" name="offers" type="checkbox" class="checkbox">
-                                              </div>
-                                              <div class="ml-3 text-md">
-                                              <label for="offers" class="medium">Omega 3</label>
-                                              </div>
-                                          </div>
-                                          </div>
-                                      <div>
-                                          <div class="flex items-start">
-                                              <div class="h-5 flex items-center">
-                                              <input id="offers" name="offers" type="checkbox" class="checkbox">
-                                              </div>
-                                              <div class="ml-3 text-md">
-                                              <label for="offers" class="medium">Vitamina C</label>
-                                              </div>
-                                          </div>
-                                          </div>
-                                      <div>
-                                          <div class="flex items-start">
-                                              <div class="h-5 flex items-center">
-                                              <input id="offers" name="offers" type="checkbox" class="checkbox">
-                                              </div>
-                                              <div class="ml-3 text-md">
-                                              <label for="offers" class="medium">Ácido fólico</label>
-                                              </div>
-                                          </div>
-                                          </div>
-                                      <div>
-                                          <div class="flex items-start">
-                                              <div class="h-5 flex items-center">
-                                              <input id="offers" name="offers" type="checkbox" class="checkbox">
-                                              </div>
-                                              <div class="ml-3 text-md">
-                                              <label for="offers" class="medium">Calcio </label>
-                                              </div>
-                                          </div>
-                                          </div>
-                                      <div>
-                                          <div class="flex items-start">
-                                              <div class="h-5 flex items-center">
-                                              <input id="offers" name="offers" type="checkbox" class="checkbox">
-                                              </div>
-                                              <div class="ml-3 text-md">
-                                              <label for="offers" class="medium">Fibra </label>
-                                              </div>
-                                          </div>
-                                        </div>
-                                      
-                                  </div>
-                              </fieldset>
-
-
-																<div class="col-span-6 sm:col-span-4 mt-8">
-																		<label for="motive" class="text-sm">Otro suplemento</label>
-																		<input type="text" name="motive" id="motive" autocomplete="motive" class="placeholder">
-
-                              </div>
-                          </div>
-                      </div>
-                  </div>
-              </div> <!-- fin card Suplementos-->
-
-                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6 mt-6"> <!-- Inicia card Habitos --> 
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
-                            <h3 >Hábitos</h3>
+                            <h3>Suplementos</h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                        
+                            <div class="mt-3 md:mt-3 md:col-span-3">
+                                <fieldset>
+                                    <legend class="text-base font-medium text-gray-900"></legend>
+                                    <div class="mt-4 grid grid-cols-4 gap-2">
+                                        <div class="flex items-start">
+                                            <div class="h-5 flex items-center">
+                                                <input id="comments" name="comments" type="checkbox" class="checkbox">
+                                            </div>
+                                            <div class="ml-3 text-md">
+                                                <label for="comments" class="medium">Ninguno</label>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="candidates" name="candidates" type="checkbox"
+                                                        class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="candidates" class="medium">Proteína</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Multivitamínico</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Omega 3</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Vitamina C</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Ácido fólico</label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Calcio </label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div>
+                                            <div class="flex items-start">
+                                                <div class="h-5 flex items-center">
+                                                    <input id="offers" name="offers" type="checkbox" class="checkbox">
+                                                </div>
+                                                <div class="ml-3 text-md">
+                                                    <label for="offers" class="medium">Fibra </label>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </fieldset>
+                                <div class="col-span-6 sm:col-span-4 mt-8">
+                                    <label for="motive" class="text-sm">Otro suplemento</label>
+                                    <input type="text" name="motive" id="motive" autocomplete="motive"
+                                        class="placeholder">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin card Suplementos-->
+
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6 mt-6">
+                    <!-- Inicia card Habitos -->
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Hábitos</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+
                             <div class="mt-5 md:mt-5 md:col-span-3">
                                 <form action="#" method="POST">
                                     <div class="grid grid-cols-6 gap-6">
 
                                         <div class="col-span-6 sm:col-span-2">
-                                          <label for="wakeup-time" class="text-sm">Hora en que se levanta</label>
-                                          <div class="mt-1 relative rounded-md">
-                                            <input type="text" name="wakeup-time" id="wakeup-time" class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md" placeholder="00">
-                                            <div class="absolute inset-y-0 right-0 flex items-center">
-                                            <label for="wakeup-time" class="sr-only">wakeup-time</label>
-                                            <div>
-																							<div class="max-w-screen-2xl mt-1">
-																									<div
-																													x-data="select({ data: { am: 'AM', pm: 'PM'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'AM' })"
-																													x-init="init()"
-																													@click.away="closeListbox()"
-																													@keydown.escape="closeListbox()"
-																													class="relative"
-																									>
-																													<span class="inline-block w-full rounded-md shadow-sm">
-																																<button type="button"
-																																				x-ref="button"
-																																				@click="toggleListboxVisibility()"
-																																				:aria-expanded="open"
-																																				aria-haspopup="listbox"
-																																				class="focus:ring-indigo-500 focus:border-indigo-500 h-full py-0 pl-0 pr-10 border-transparent bg-transparent text-gray-500 sm:text-sm rounded-md"
-																																>
-																																			<span
-																																							x-show="! open"
-																																							x-text="value in options ? options[value] : placeholder"
-																																							:class="{ 'text-gray-500': ! (value in options) }"
-																																							class="block truncate"
-																																			></span>
-																					
-																																			<input
-																																							x-ref="search"
-																																							x-show="open"
-																																							x-model="search"
-																																							@keydown.enter.stop.prevent="selectOption()"
-																																							@keydown.arrow-up.prevent="focusPreviousOption()"
-																																							@keydown.arrow-down.prevent="focusNextOption()"
-																																							type="search"
-																																							class="w-full h-full form-control focus:outline-none"
-																																			/>
-																					
-																																			<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																					<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																							<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																										stroke-linejoin="round"></path>
-																																					</svg>
-																																			</span>
-																																</button>
-																													</span>
-																					
-																											<div
-																															x-show="open"
-																															x-transition:leave="transition ease-in duration-100"
-																															x-transition:leave-start="opacity-100"
-																															x-transition:leave-end="opacity-0"
-																															x-cloak
-																															class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																											>
-																													<ul
-																																	x-ref="listbox"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	role="listbox"
-																																	:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																	tabindex="-1"
-																																	class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																													>
-																															<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																	<li
-																																					:id="name + 'Option' + focusedOptionIndex"
-																																					@click="selectOption()"
-																																					@mouseenter="focusedOptionIndex = index"
-																																					@mouseleave="focusedOptionIndex = null"
-																																					role="option"
-																																					:aria-selected="focusedOptionIndex === index"
-																																					:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																					class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																	>
-																																					<span x-text="Object.values(options)[index]"
-																																								:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																								class="block font-normal truncate"
-																																					></span>
-																					
-																																			<span
-																																							x-show="key === value"
-																																							:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																							class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																			>
-																																							<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																									<path fill-rule="evenodd"
-																																												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																												clip-rule="evenodd"/>
-																																							</svg>
-																																					</span>
-																																	</li>
-																															</template>
-																					
-																															<div
-																																			x-show="! Object.keys(options).length"
-																																			x-text="emptyOptionsMessage"
-																																			class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																													</ul>
-																											</div>
-																									</div>
-																					
-																									<script>
-																											function select(config) {
-																													return {
-																															data: config.data,
-																					
-																															emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																					
-																															focusedOptionIndex: null,
-																					
-																															name: config.name,
-																					
-																															open: false,
-																					
-																															options: {},
-																					
-																															placeholder: config.placeholder ?? 'Select an option',
-																					
-																															search: '',
-																					
-																															value: config.value,
-																					
-																															closeListbox: function () {
-																																	this.open = false
-																					
-																																	this.focusedOptionIndex = null
-																					
-																																	this.search = ''
-																															},
-																					
-																															focusNextOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																					
-																																	if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																					
-																																	this.focusedOptionIndex++
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															focusPreviousOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																					
-																																	if (this.focusedOptionIndex <= 0) return
-																					
-																																	this.focusedOptionIndex--
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															init: function () {
-																																	this.options = this.data
-																					
-																																	if (!(this.value in this.options)) this.value = null
-																					
-																																	this.$watch('search', ((value) => {
-																																			if (!this.open || !value) return this.options = this.data
-																					
-																																			this.options = Object.keys(this.data)
-																																					.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																					.reduce((options, key) => {
-																																							options[key] = this.data[key]
-																																							return options
-																																					}, {})
-																																	}))
-																															},
-																					
-																															selectOption: function () {
-																																	if (!this.open) return this.toggleListboxVisibility()
-																					
-																																	this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																					
-																																	this.closeListbox()
-																															},
-																					
-																															toggleListboxVisibility: function () {
-																																	if (this.open) return this.closeListbox()
-																					
-																																	this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																					
-																																	if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																					
-																																	this.open = true
-																					
-																																	this.$nextTick(() => {
-																																			this.$refs.search.focus()
-																					
-																																			this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																					block: "center"
-																																			})
-																																	})
-																															},
-																													}
-																											}
-																									</script>
-																							</div>
-																					</div>
-																						<!--Fin select-->
+                                            <label for="wakeup-time" class="text-sm">Hora en que se levanta</label>
+                                            <div class="mt-1 relative rounded-md">
+                                                <input type="text" name="wakeup-time" id="wakeup-time"
+                                                    class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md"
+                                                    placeholder="00">
+                                                <div class="absolute inset-y-0 right-0 flex items-center">
+                                                    <label for="wakeup-time" class="sr-only">wakeup-time</label>
+                                                    <div>
+                                                        <div class="max-w-screen-2xl mt-1">
+                                                            <div>
+                                                                <select id="wakeup" name="wakeup" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                    <option>AM</option>
+                                                                    <option>PM</option>
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <!--Fin select-->
+                                                </div>
                                             </div>
-                                          </div>
                                         </div>
 
                                         <div class="col-span-6 sm:col-span-2">
-                                          <label for="sleep-time" class="text-sm">Hora en que se duerme</label>
-                                          <div class="mt-1 relative rounded-md">
-                                            <input type="text" name="sleep-time" id="sleep-time" class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md" placeholder="00">
-                                            <div class="absolute inset-y-0 right-0 flex items-center">
-                                            <label for="sleep-time" class="sr-only">sleep-time</label>
-                                            <div>
-																							<div class="max-w-screen-2xl mt-1">
-																									<div
-																													x-data="select({ data: { am: 'AM', pm: 'PM'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'AM' })"
-																													x-init="init()"
-																													@click.away="closeListbox()"
-																													@keydown.escape="closeListbox()"
-																													class="relative"
-																									>
-																													<span class="inline-block w-full rounded-md shadow-sm">
-																																<button type="button"
-																																				x-ref="button"
-																																				@click="toggleListboxVisibility()"
-																																				:aria-expanded="open"
-																																				aria-haspopup="listbox"
-																																				class="focus:ring-indigo-500 focus:border-indigo-500 h-full py-0 pl-0 pr-10 border-transparent bg-transparent text-gray-500 sm:text-sm rounded-md"
-																																>
-																																			<span
-																																							x-show="! open"
-																																							x-text="value in options ? options[value] : placeholder"
-																																							:class="{ 'text-gray-500': ! (value in options) }"
-																																							class="block truncate"
-																																			></span>
-																					
-																																			<input
-																																							x-ref="search"
-																																							x-show="open"
-																																							x-model="search"
-																																							@keydown.enter.stop.prevent="selectOption()"
-																																							@keydown.arrow-up.prevent="focusPreviousOption()"
-																																							@keydown.arrow-down.prevent="focusNextOption()"
-																																							type="search"
-																																							class="w-full h-full form-control focus:outline-none"
-																																			/>
-																					
-																																			<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																					<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																							<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																										stroke-linejoin="round"></path>
-																																					</svg>
-																																			</span>
-																																</button>
-																													</span>
-																					
-																											<div
-																															x-show="open"
-																															x-transition:leave="transition ease-in duration-100"
-																															x-transition:leave-start="opacity-100"
-																															x-transition:leave-end="opacity-0"
-																															x-cloak
-																															class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																											>
-																													<ul
-																																	x-ref="listbox"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	role="listbox"
-																																	:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																	tabindex="-1"
-																																	class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																													>
-																															<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																	<li
-																																					:id="name + 'Option' + focusedOptionIndex"
-																																					@click="selectOption()"
-																																					@mouseenter="focusedOptionIndex = index"
-																																					@mouseleave="focusedOptionIndex = null"
-																																					role="option"
-																																					:aria-selected="focusedOptionIndex === index"
-																																					:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																					class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																	>
-																																					<span x-text="Object.values(options)[index]"
-																																								:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																								class="block font-normal truncate"
-																																					></span>
-																					
-																																			<span
-																																							x-show="key === value"
-																																							:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																							class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																			>
-																																							<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																									<path fill-rule="evenodd"
-																																												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																												clip-rule="evenodd"/>
-																																							</svg>
-																																					</span>
-																																	</li>
-																															</template>
-																					
-																															<div
-																																			x-show="! Object.keys(options).length"
-																																			x-text="emptyOptionsMessage"
-																																			class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																													</ul>
-																											</div>
-																									</div>
-																					
-																									<script>
-																											function select(config) {
-																													return {
-																															data: config.data,
-																					
-																															emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																					
-																															focusedOptionIndex: null,
-																					
-																															name: config.name,
-																					
-																															open: false,
-																					
-																															options: {},
-																					
-																															placeholder: config.placeholder ?? 'Select an option',
-																					
-																															search: '',
-																					
-																															value: config.value,
-																					
-																															closeListbox: function () {
-																																	this.open = false
-																					
-																																	this.focusedOptionIndex = null
-																					
-																																	this.search = ''
-																															},
-																					
-																															focusNextOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																					
-																																	if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																					
-																																	this.focusedOptionIndex++
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															focusPreviousOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																					
-																																	if (this.focusedOptionIndex <= 0) return
-																					
-																																	this.focusedOptionIndex--
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															init: function () {
-																																	this.options = this.data
-																					
-																																	if (!(this.value in this.options)) this.value = null
-																					
-																																	this.$watch('search', ((value) => {
-																																			if (!this.open || !value) return this.options = this.data
-																					
-																																			this.options = Object.keys(this.data)
-																																					.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																					.reduce((options, key) => {
-																																							options[key] = this.data[key]
-																																							return options
-																																					}, {})
-																																	}))
-																															},
-																					
-																															selectOption: function () {
-																																	if (!this.open) return this.toggleListboxVisibility()
-																					
-																																	this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																					
-																																	this.closeListbox()
-																															},
-																					
-																															toggleListboxVisibility: function () {
-																																	if (this.open) return this.closeListbox()
-																					
-																																	this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																					
-																																	if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																					
-																																	this.open = true
-																					
-																																	this.$nextTick(() => {
-																																			this.$refs.search.focus()
-																					
-																																			this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																					block: "center"
-																																			})
-																																	})
-																															},
-																													}
-																											}
-																									</script>
-																							</div>
-																					</div>
-																						<!--Fin select-->
+                                            <label for="sleep-time" class="text-sm">Hora en que se duerme</label>
+                                            <div class="mt-1 relative rounded-md">
+                                                <input type="text" name="sleep-time" id="sleep-time"
+                                                    class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md"
+                                                    placeholder="00">
+                                                <div class="absolute inset-y-0 right-0 flex items-center">
+                                                    <label for="sleep-time" class="sr-only">sleep-time</label>
+                                                    <div>
+                                                        <div class="max-w-screen-2xl mt-1">
+                                                            <div>
+                                                                <select id="sleep" name="sleep" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                    <option>AM</option>
+                                                                    <option>PM</option>
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <!--Fin select-->
+                                                </div>
                                             </div>
-                                          </div>
                                         </div>
 
                                         <div class="col-span-6 sm:col-span-2">
-                                          <label for="hungry-time" class="text-sm">Hora con más hambre</label>
-                                          <div class="mt-1 relative rounded-md">
-                                            <input type="text" name="hungry-time" id="hungry-time" class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md" placeholder="00">
-                                            <div class="absolute inset-y-0 right-0 flex items-center">
-                                            <label for="hungry-time" class="sr-only">hungry-time</label>
-                                            <div>
-																							<div class="max-w-screen-2xl mt-1">
-																									<div
-																													x-data="select({ data: { am: 'AM', pm: 'PM'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'AM' })"
-																													x-init="init()"
-																													@click.away="closeListbox()"
-																													@keydown.escape="closeListbox()"
-																													class="relative"
-																									>
-																													<span class="inline-block w-full rounded-md shadow-sm">
-																																<button type="button"
-																																				x-ref="button"
-																																				@click="toggleListboxVisibility()"
-																																				:aria-expanded="open"
-																																				aria-haspopup="listbox"
-																																				class="focus:ring-indigo-500 focus:border-indigo-500 h-full py-0 pl-0 pr-10 border-transparent bg-transparent text-gray-500 sm:text-sm rounded-md"
-																																>
-																																			<span
-																																							x-show="! open"
-																																							x-text="value in options ? options[value] : placeholder"
-																																							:class="{ 'text-gray-500': ! (value in options) }"
-																																							class="block truncate"
-																																			></span>
-																					
-																																			<input
-																																							x-ref="search"
-																																							x-show="open"
-																																							x-model="search"
-																																							@keydown.enter.stop.prevent="selectOption()"
-																																							@keydown.arrow-up.prevent="focusPreviousOption()"
-																																							@keydown.arrow-down.prevent="focusNextOption()"
-																																							type="search"
-																																							class="w-full h-full form-control focus:outline-none"
-																																			/>
-																					
-																																			<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																					<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																							<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																										stroke-linejoin="round"></path>
-																																					</svg>
-																																			</span>
-																																</button>
-																													</span>
-																					
-																											<div
-																															x-show="open"
-																															x-transition:leave="transition ease-in duration-100"
-																															x-transition:leave-start="opacity-100"
-																															x-transition:leave-end="opacity-0"
-																															x-cloak
-																															class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																											>
-																													<ul
-																																	x-ref="listbox"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	role="listbox"
-																																	:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																	tabindex="-1"
-																																	class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																													>
-																															<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																	<li
-																																					:id="name + 'Option' + focusedOptionIndex"
-																																					@click="selectOption()"
-																																					@mouseenter="focusedOptionIndex = index"
-																																					@mouseleave="focusedOptionIndex = null"
-																																					role="option"
-																																					:aria-selected="focusedOptionIndex === index"
-																																					:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																					class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																	>
-																																					<span x-text="Object.values(options)[index]"
-																																								:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																								class="block font-normal truncate"
-																																					></span>
-																					
-																																			<span
-																																							x-show="key === value"
-																																							:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																							class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																			>
-																																							<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																									<path fill-rule="evenodd"
-																																												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																												clip-rule="evenodd"/>
-																																							</svg>
-																																					</span>
-																																	</li>
-																															</template>
-																					
-																															<div
-																																			x-show="! Object.keys(options).length"
-																																			x-text="emptyOptionsMessage"
-																																			class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																													</ul>
-																											</div>
-																									</div>
-																					
-																									<script>
-																											function select(config) {
-																													return {
-																															data: config.data,
-																					
-																															emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																					
-																															focusedOptionIndex: null,
-																					
-																															name: config.name,
-																					
-																															open: false,
-																					
-																															options: {},
-																					
-																															placeholder: config.placeholder ?? 'Select an option',
-																					
-																															search: '',
-																					
-																															value: config.value,
-																					
-																															closeListbox: function () {
-																																	this.open = false
-																					
-																																	this.focusedOptionIndex = null
-																					
-																																	this.search = ''
-																															},
-																					
-																															focusNextOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																					
-																																	if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																					
-																																	this.focusedOptionIndex++
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															focusPreviousOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																					
-																																	if (this.focusedOptionIndex <= 0) return
-																					
-																																	this.focusedOptionIndex--
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															init: function () {
-																																	this.options = this.data
-																					
-																																	if (!(this.value in this.options)) this.value = null
-																					
-																																	this.$watch('search', ((value) => {
-																																			if (!this.open || !value) return this.options = this.data
-																					
-																																			this.options = Object.keys(this.data)
-																																					.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																					.reduce((options, key) => {
-																																							options[key] = this.data[key]
-																																							return options
-																																					}, {})
-																																	}))
-																															},
-																					
-																															selectOption: function () {
-																																	if (!this.open) return this.toggleListboxVisibility()
-																					
-																																	this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																					
-																																	this.closeListbox()
-																															},
-																					
-																															toggleListboxVisibility: function () {
-																																	if (this.open) return this.closeListbox()
-																					
-																																	this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																					
-																																	if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																					
-																																	this.open = true
-																					
-																																	this.$nextTick(() => {
-																																			this.$refs.search.focus()
-																					
-																																			this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																					block: "center"
-																																			})
-																																	})
-																															},
-																													}
-																											}
-																									</script>
-																							</div>
-																					</div>
-																						<!--Fin select-->
+                                            <label for="hungry-time" class="text-sm">Hora con más hambre</label>
+                                            <div class="mt-1 relative rounded-md">
+                                                <input type="text" name="hungry-time" id="hungry-time"
+                                                    class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md"
+                                                    placeholder="00">
+                                                <div class="absolute inset-y-0 right-0 flex items-center">
+                                                    <label for="hungry-time" class="sr-only">hungry-time</label>
+                                                    <div>
+                                                        <div class="max-w-screen-2xl mt-1">
+                                                            <div>
+                                                                <select id="hungry" name="hungry" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                    <option>AM</option>
+                                                                    <option>PM</option>
+                                                                </select>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <!--Fin select-->
+                                                </div>
                                             </div>
-                                          </div>
                                         </div>
 
                                         <div class="col-span-6 sm:col-span-4">
-                                         
-																						<div>
-																						<label id="listbox-label-prepare-food" class="text-sm">
-																							Tiempo empleado para preparar alimentos
-																						</label>
-																						<div class="max-w-screen-2xl mt-1">
-																								<div
-																												x-data="select({ data: { no: 'No cocina', min: '30 minutos al día', hrs: '1 - 2 horas al día', fines: 'Sólo fines de semana'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'Elige una opción' })"
-																												x-init="init()"
-																												@click.away="closeListbox()"
-																												@keydown.escape="closeListbox()"
-																												class="relative"
-																								>
-																												<span class="inline-block w-full rounded-md shadow-sm">
-																															<button type="button"
-																																			x-ref="button"
-																																			@click="toggleListboxVisibility()"
-																																			:aria-expanded="open"
-																																			aria-haspopup="listbox"
-																																			class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																															>
-																																		<span
-																																						x-show="! open"
-																																						x-text="value in options ? options[value] : placeholder"
-																																						:class="{ 'text-gray-500': ! (value in options) }"
-																																						class="block truncate"
-																																		></span>
-																				
-																																		<input
-																																						x-ref="search"
-																																						x-show="open"
-																																						x-model="search"
-																																						@keydown.enter.stop.prevent="selectOption()"
-																																						@keydown.arrow-up.prevent="focusPreviousOption()"
-																																						@keydown.arrow-down.prevent="focusNextOption()"
-																																						type="search"
-																																						class="w-full h-full form-control focus:outline-none"
-																																		/>
-																				
-																																		<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																				<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																						<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																									stroke-linejoin="round"></path>
-																																				</svg>
-																																		</span>
-																															</button>
-																												</span>
-																				
-																										<div
-																														x-show="open"
-																														x-transition:leave="transition ease-in duration-100"
-																														x-transition:leave-start="opacity-100"
-																														x-transition:leave-end="opacity-0"
-																														x-cloak
-																														class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																										>
-																												<ul
-																																x-ref="listbox"
-																																@keydown.enter.stop.prevent="selectOption()"
-																																@keydown.arrow-up.prevent="focusPreviousOption()"
-																																@keydown.arrow-down.prevent="focusNextOption()"
-																																role="listbox"
-																																:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																tabindex="-1"
-																																class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																												>
-																														<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																<li
-																																				:id="name + 'Option' + focusedOptionIndex"
-																																				@click="selectOption()"
-																																				@mouseenter="focusedOptionIndex = index"
-																																				@mouseleave="focusedOptionIndex = null"
-																																				role="option"
-																																				:aria-selected="focusedOptionIndex === index"
-																																				:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																				class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																>
-																																				<span x-text="Object.values(options)[index]"
-																																							:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																							class="block font-normal truncate"
-																																				></span>
-																				
-																																		<span
-																																						x-show="key === value"
-																																						:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																						class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																		>
-																																						<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																								<path fill-rule="evenodd"
-																																											d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																											clip-rule="evenodd"/>
-																																						</svg>
-																																				</span>
-																																</li>
-																														</template>
-																				
-																														<div
-																																		x-show="! Object.keys(options).length"
-																																		x-text="emptyOptionsMessage"
-																																		class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																												</ul>
-																										</div>
-																								</div>
-																				
-																								<script>
-																										function select(config) {
-																												return {
-																														data: config.data,
-																				
-																														emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																				
-																														focusedOptionIndex: null,
-																				
-																														name: config.name,
-																				
-																														open: false,
-																				
-																														options: {},
-																				
-																														placeholder: config.placeholder ?? 'Select an option',
-																				
-																														search: '',
-																				
-																														value: config.value,
-																				
-																														closeListbox: function () {
-																																this.open = false
-																				
-																																this.focusedOptionIndex = null
-																				
-																																this.search = ''
-																														},
-																				
-																														focusNextOption: function () {
-																																if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																				
-																																if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																				
-																																this.focusedOptionIndex++
-																				
-																																this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																		block: "center",
-																																})
-																														},
-																				
-																														focusPreviousOption: function () {
-																																if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																				
-																																if (this.focusedOptionIndex <= 0) return
-																				
-																																this.focusedOptionIndex--
-																				
-																																this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																		block: "center",
-																																})
-																														},
-																				
-																														init: function () {
-																																this.options = this.data
-																				
-																																if (!(this.value in this.options)) this.value = null
-																				
-																																this.$watch('search', ((value) => {
-																																		if (!this.open || !value) return this.options = this.data
-																				
-																																		this.options = Object.keys(this.data)
-																																				.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																				.reduce((options, key) => {
-																																						options[key] = this.data[key]
-																																						return options
-																																				}, {})
-																																}))
-																														},
-																				
-																														selectOption: function () {
-																																if (!this.open) return this.toggleListboxVisibility()
-																				
-																																this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																				
-																																this.closeListbox()
-																														},
-																				
-																														toggleListboxVisibility: function () {
-																																if (this.open) return this.closeListbox()
-																				
-																																this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																				
-																																if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																				
-																																this.open = true
-																				
-																																this.$nextTick(() => {
-																																		this.$refs.search.focus()
-																				
-																																		this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																				block: "center"
-																																		})
-																																})
-																														},
-																												}
-																										}
-																								</script>
-																						</div>
-																				</div>
-																					<!--Fin select-->
-                                      </div>
+
+                                            <div>
+                                                    <label for="prepare-food" class="block text-sm">Tiempo empleado para preparar alimentos </label>
+                                                    <select id="prepare-food" name="prepare-food" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Nunca</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>Diariamente</option>
+                                                    </select>
+                                                </div>
+                                        </div>
 
                                     </div>
                                 </form>
@@ -1419,5797 +418,595 @@
                     </div>
                 </div> <!-- fin card habitos-->
 
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6 mt-6">
+                    <!-- Inicia card dieta habitual -->
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Dieta habitual</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0">
+                            </div>
 
+                            <div class="mt-5 md:mt-5 md:col-span-3">
 
+                                <div>
+                                    <label for="breakfast" class="text-sm">Desayuno</label>
+                                    <div class="flex flex-col mt-3">
+                                        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                                            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                                                <div
+                                                    class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                                                    <table class="min-w-full  divide-y divide-gray-200 table-fixed">
+                                                        <thead class="bg-gray-50">
+                                                            <tr>
+                                                                <th scope="col"
+                                                                    class="w-1/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Horario
+                                                                </th>
+                                                                <th scope="col"
+                                                                    class="w-1/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Lugar
+                                                                </th>
+                                                                <th scope="col"
+                                                                    class="w-1/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Tipo
+                                                                </th>
+                                                                <th scope="col"
+                                                                    class="w-3/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Descripción
+                                                                </th>
 
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody class="bg-white divide-y divide-gray-200">
+                                                            <tr>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                                                    <input type="time" name="motive" id="motive"
+                                                                        autocomplete="motive"
+                                                                        class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-white rounded-md">
+                                                                </td>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                                    <div>
+                                                                        <div class="max-w-screen-2xl mt-1">
+                                                                            <div>
+                                                                                <select id="place" name="place" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                                    <option>Casa</option>
+                                                                                    <option>Trabajo</option>
+                                                                                    <option>Establecimiento</option>
+                                                                                </select>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <!--Fin select-->
+                                                                </td>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                                            <div>
+                                                                                <div class="max-w-screen-2xl mt-1">
+                                                                                    <div>
+                                                                                        <select id="type" name="type" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                                            <option>Preparado</option>
+                                                                                            <option>Comprada</option>
+                                                                                            <option>Comedor</option>
+                                                                                        </select>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <!--Fin select-->
+                                                                </td>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-normal text-sm text-gray-500">
+                                                                    <input type="text" name="motive" id="motive"
+                                                                        autocomplete="motive"
+                                                                        class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-white rounded-md">
+                                                                </td>
 
+                                                            </tr>
+
+                                                            <!-- More people... -->
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="mt-4">
+                                    <label for="breakfast" class="text-sm">Colación</label>
+                                    <div class="flex flex-col mt-3">
+                                        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+                                            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                                                <div
+                                                    class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                                                    <table class="min-w-full  divide-y divide-gray-200 table-fixed">
+                                                        <thead class="bg-gray-50">
+                                                            <tr>
+                                                                <th scope="col"
+                                                                    class="w-1/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Horario
+                                                                </th>
+                                                                <th scope="col"
+                                                                    class="w-1/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Lugar
+                                                                </th>
+                                                                <th scope="col"
+                                                                    class="w-1/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Tipo
+                                                                </th>
+                                                                <th scope="col"
+                                                                    class="w-3/6 px-6 py-3 text-left text-xs medium uppercase tracking-wider">
+                                                                    Descripción
+                                                                </th>
+
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody class="bg-white divide-y divide-gray-200">
+                                                            <tr>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                                                    <input type="time" name="motive" id="motive"
+                                                                        autocomplete="motive"
+                                                                        class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-white rounded-md">
+                                                                </td>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                                    <div>
+                                                                        <div class="max-w-screen-2xl mt-1">
+                                                                            <div>
+                                                                                <select id="place1" name="place1" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                                    <option>Casa</option>
+                                                                                    <option>Trabajo</option>
+                                                                                    <option>Establecimiento</option>
+                                                                                </select>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <!--Fin select-->
+                                                                </td>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                                                            <div>
+                                                                                <div class="max-w-screen-2xl mt-1">
+                                                                                    <div>
+                                                                                        <select id="type1" name="type1" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                                                            <option>Preparado</option>
+                                                                                            <option>Comprada</option>
+                                                                                            <option>Comedor</option>
+                                                                                        </select>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </div>
+                                                                            <!--Fin select-->
+                                                                </td>
+                                                                <td
+                                                                    class="px-6 py-4 whitespace-normal text-sm text-gray-500">
+                                                                    <input type="text" name="motive" id="motive"
+                                                                        autocomplete="motive"
+                                                                        class="mt-1 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-white rounded-md">
+                                                                </td>
+
+                                                            </tr>
+
+                                                            <!-- More people... -->
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin card dieta habitual-->
 
             </div>
 
-						<!-- Relación con los alimentos--> 
+                                                                <input x-ref="search" x-show="open" x-model="search"
+                                                                    @keydown.enter.stop.prevent="selectOption()"
+                                                                    @keydown.arrow-up.prevent="focusPreviousOption()"
+                                                                    @keydown.arrow-down.prevent="focusNextOption()"
+                                                                    type="search"
+                                                                    class="w-full h-full form-control focus:outline-none" />
 
-						<div class="bg-gray-100 w-full px-6 py-5">
-							<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-									<div class="md:grid md:grid-cols-3 md:gap-6">
-											<div class="md:col-span-3">
-													<h3 >Dieta habitual</h3>
-													<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-													<!--Desayuno-->
-													<label for="breakfast" class="text-sm text-gray-800">Desayuno </label>
-													<div class="border-t border-gray-200 px-0 sm:my-2 sm:mx-0"></div>
+            <!-- Relación con los alimentos-->
+            <div class="bg-gray-100 w-full px-6 py-5">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Relación con los alimentos</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
 
-													<div class="mt-5 md:mt-5 md:col-span-3">
-															<form action="#" method="POST">
-																	<div class="grid grid-cols-6 gap-6">
-																			<div class="col-span-6 sm:col-span-2">
-                                          <label for="time" class="text-sm">Hora </label>
-                                          <div class="mt-1 relative rounded-md">
-                                            <input type="text" name="time" id="time" class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md" placeholder="00">
-                                            <div class="absolute inset-y-0 right-0 flex items-center">
-                                            <label for="time" class="sr-only">time</label>
+                            <div class="mt-5 md:mt-5 md:col-span-3">
+                                <form action="#" method="POST">
+                                    <div class="grid grid-cols-6 gap-6">
+                                        <div class="col-span-6 sm:col-span-3">
+
                                             <div>
-																							<div class="max-w-screen-2xl mt-1">
-																									<div
-																													x-data="select({ data: { am: 'AM', pm: 'PM'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'AM' })"
-																													x-init="init()"
-																													@click.away="closeListbox()"
-																													@keydown.escape="closeListbox()"
-																													class="relative"
-																									>
-																													<span class="inline-block w-full rounded-md shadow-sm">
-																																<button type="button"
-																																				x-ref="button"
-																																				@click="toggleListboxVisibility()"
-																																				:aria-expanded="open"
-																																				aria-haspopup="listbox"
-																																				class="focus:ring-indigo-500 focus:border-indigo-500 h-full py-0 pl-0 pr-10 border-transparent bg-transparent text-gray-500 sm:text-sm rounded-md"
-																																>
-																																			<span
-																																							x-show="! open"
-																																							x-text="value in options ? options[value] : placeholder"
-																																							:class="{ 'text-gray-500': ! (value in options) }"
-																																							class="block truncate"
-																																			></span>
-																					
-																																			<input
-																																							x-ref="search"
-																																							x-show="open"
-																																							x-model="search"
-																																							@keydown.enter.stop.prevent="selectOption()"
-																																							@keydown.arrow-up.prevent="focusPreviousOption()"
-																																							@keydown.arrow-down.prevent="focusNextOption()"
-																																							type="search"
-																																							class="w-full h-full form-control focus:outline-none"
-																																			/>
-																					
-																																			<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																					<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																							<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																										stroke-linejoin="round"></path>
-																																					</svg>
-																																			</span>
-																																</button>
-																													</span>
-																					
-																											<div
-																															x-show="open"
-																															x-transition:leave="transition ease-in duration-100"
-																															x-transition:leave-start="opacity-100"
-																															x-transition:leave-end="opacity-0"
-																															x-cloak
-																															class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																											>
-																													<ul
-																																	x-ref="listbox"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	role="listbox"
-																																	:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																	tabindex="-1"
-																																	class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																													>
-																															<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																	<li
-																																					:id="name + 'Option' + focusedOptionIndex"
-																																					@click="selectOption()"
-																																					@mouseenter="focusedOptionIndex = index"
-																																					@mouseleave="focusedOptionIndex = null"
-																																					role="option"
-																																					:aria-selected="focusedOptionIndex === index"
-																																					:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																					class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																	>
-																																					<span x-text="Object.values(options)[index]"
-																																								:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																								class="block font-normal truncate"
-																																					></span>
-																					
-																																			<span
-																																							x-show="key === value"
-																																							:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																							class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																			>
-																																							<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																									<path fill-rule="evenodd"
-																																												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																												clip-rule="evenodd"/>
-																																							</svg>
-																																					</span>
-																																	</li>
-																															</template>
-																					
-																															<div
-																																			x-show="! Object.keys(options).length"
-																																			x-text="emptyOptionsMessage"
-																																			class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																													</ul>
-																											</div>
-																									</div>
-																					
-																									<script>
-																											function select(config) {
-																													return {
-																															data: config.data,
-																					
-																															emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																					
-																															focusedOptionIndex: null,
-																					
-																															name: config.name,
-																					
-																															open: false,
-																					
-																															options: {},
-																					
-																															placeholder: config.placeholder ?? 'Select an option',
-																					
-																															search: '',
-																					
-																															value: config.value,
-																					
-																															closeListbox: function () {
-																																	this.open = false
-																					
-																																	this.focusedOptionIndex = null
-																					
-																																	this.search = ''
-																															},
-																					
-																															focusNextOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																					
-																																	if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																					
-																																	this.focusedOptionIndex++
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															focusPreviousOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																					
-																																	if (this.focusedOptionIndex <= 0) return
-																					
-																																	this.focusedOptionIndex--
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															init: function () {
-																																	this.options = this.data
-																					
-																																	if (!(this.value in this.options)) this.value = null
-																					
-																																	this.$watch('search', ((value) => {
-																																			if (!this.open || !value) return this.options = this.data
-																					
-																																			this.options = Object.keys(this.data)
-																																					.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																					.reduce((options, key) => {
-																																							options[key] = this.data[key]
-																																							return options
-																																					}, {})
-																																	}))
-																															},
-																					
-																															selectOption: function () {
-																																	if (!this.open) return this.toggleListboxVisibility()
-																					
-																																	this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																					
-																																	this.closeListbox()
-																															},
-																					
-																															toggleListboxVisibility: function () {
-																																	if (this.open) return this.closeListbox()
-																					
-																																	this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																					
-																																	if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																					
-																																	this.open = true
-																					
-																																	this.$nextTick(() => {
-																																			this.$refs.search.focus()
-																					
-																																			this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																					block: "center"
-																																			})
-																																	})
-																															},
-																													}
-																											}
-																									</script>
-																							</div>
-																					</div>
-																						<!--Fin select-->
-                                            </div>
-                                          </div>
+                                                    <label for="distracts" class="block text-sm">Distractores a la hora de comer</label>
+                                                    <select id="distracts" name="distracts" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Televisión</option>
+                                                        <option>Celular</option>
+                                                        <option>Computadora</option>
+                                                    </select>
+                                                </div>
+
                                         </div>
-													
-																			<div class="col-span-6 sm:col-span-2">
-																			
-																				<!--Select-->
-																	
-																	<div>
-																		<label id="listbox-label-place" class="text-sm">
-																				Lugar
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { casa: 'Casa', trabajo: 'Trabajo', establecimiento: 'Establecimiento'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'place', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
 
-																			</div>
-																				<div class="col-span-6 sm:col-span-2	">
-																			<div>
-																		<label id="listbox-label-distracts" class="text-sm">
-																				Tipo de comida
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { preparada: 'Preparada', comprada: 'Comprada', comedor: 'Comedor de trabajo'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'distracts', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-																				</div>
-																			
-																			<div class="col-span-6 sm:col-span-6 mt-2">
-																				<label for="motive" class="text-sm">Descripción de alimentos</label>
-																				<input type="text" name="motive" id="motive" autocomplete="motive" class="placeholder">
-																		</div>
-																			<!--End desayuno-->
-																			
+                                        <div class="col-span-6 sm:col-span-3">
 
-																	</div>
-																	<!--Colacion-->
-																	<label for="breakfast" class="text-sm text-gray-800 mt-6	">Colación</label>
-													<div class="border-t border-gray-200 px-0 sm:my-2 sm:mx-0"></div>
-
-													<div class="mt-5 md:mt-5 md:col-span-3">
-															<form action="#" method="POST">
-																	<div class="grid grid-cols-6 gap-6">
-																			<div class="col-span-6 sm:col-span-2">
-                                          <label for="time" class="text-sm">Hora </label>
-                                          <div class="mt-1 relative rounded-md">
-                                            <input type="text" name="time" id="time" class="mt-1 p-2 h-10 focus:ring-indigo-500 border focus:border-indigo-500 block w-full pl-2 pr-12 sm:text-md border-gray-300 rounded-md" placeholder="00">
-                                            <div class="absolute inset-y-0 right-0 flex items-center">
-                                            <label for="time" class="sr-only">time</label>
                                             <div>
-																							<div class="max-w-screen-2xl mt-1">
-																									<div
-																													x-data="select({ data: { am: 'AM', pm: 'PM'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'AM' })"
-																													x-init="init()"
-																													@click.away="closeListbox()"
-																													@keydown.escape="closeListbox()"
-																													class="relative"
-																									>
-																													<span class="inline-block w-full rounded-md shadow-sm">
-																																<button type="button"
-																																				x-ref="button"
-																																				@click="toggleListboxVisibility()"
-																																				:aria-expanded="open"
-																																				aria-haspopup="listbox"
-																																				class="focus:ring-indigo-500 focus:border-indigo-500 h-full py-0 pl-0 pr-10 border-transparent bg-transparent text-gray-500 sm:text-sm rounded-md"
-																																>
-																																			<span
-																																							x-show="! open"
-																																							x-text="value in options ? options[value] : placeholder"
-																																							:class="{ 'text-gray-500': ! (value in options) }"
-																																							class="block truncate"
-																																			></span>
-																					
-																																			<input
-																																							x-ref="search"
-																																							x-show="open"
-																																							x-model="search"
-																																							@keydown.enter.stop.prevent="selectOption()"
-																																							@keydown.arrow-up.prevent="focusPreviousOption()"
-																																							@keydown.arrow-down.prevent="focusNextOption()"
-																																							type="search"
-																																							class="w-full h-full form-control focus:outline-none"
-																																			/>
-																					
-																																			<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																					<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																							<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																										stroke-linejoin="round"></path>
-																																					</svg>
-																																			</span>
-																																</button>
-																													</span>
-																					
-																											<div
-																															x-show="open"
-																															x-transition:leave="transition ease-in duration-100"
-																															x-transition:leave-start="opacity-100"
-																															x-transition:leave-end="opacity-0"
-																															x-cloak
-																															class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																											>
-																													<ul
-																																	x-ref="listbox"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	role="listbox"
-																																	:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																																	tabindex="-1"
-																																	class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																													>
-																															<template x-for="(key, index) in Object.keys(options)" :key="index">
-																																	<li
-																																					:id="name + 'Option' + focusedOptionIndex"
-																																					@click="selectOption()"
-																																					@mouseenter="focusedOptionIndex = index"
-																																					@mouseleave="focusedOptionIndex = null"
-																																					role="option"
-																																					:aria-selected="focusedOptionIndex === index"
-																																					:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																					class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																																	>
-																																					<span x-text="Object.values(options)[index]"
-																																								:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																								class="block font-normal truncate"
-																																					></span>
-																					
-																																			<span
-																																							x-show="key === value"
-																																							:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																							class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																			>
-																																							<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																									<path fill-rule="evenodd"
-																																												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																												clip-rule="evenodd"/>
-																																							</svg>
-																																					</span>
-																																	</li>
-																															</template>
-																					
-																															<div
-																																			x-show="! Object.keys(options).length"
-																																			x-text="emptyOptionsMessage"
-																																			class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																													</ul>
-																											</div>
-																									</div>
-																					
-																									<script>
-																											function select(config) {
-																													return {
-																															data: config.data,
-																					
-																															emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																					
-																															focusedOptionIndex: null,
-																					
-																															name: config.name,
-																					
-																															open: false,
-																					
-																															options: {},
-																					
-																															placeholder: config.placeholder ?? 'Select an option',
-																					
-																															search: '',
-																					
-																															value: config.value,
-																					
-																															closeListbox: function () {
-																																	this.open = false
-																					
-																																	this.focusedOptionIndex = null
-																					
-																																	this.search = ''
-																															},
-																					
-																															focusNextOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																					
-																																	if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																					
-																																	this.focusedOptionIndex++
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															focusPreviousOption: function () {
-																																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																					
-																																	if (this.focusedOptionIndex <= 0) return
-																					
-																																	this.focusedOptionIndex--
-																					
-																																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																			block: "center",
-																																	})
-																															},
-																					
-																															init: function () {
-																																	this.options = this.data
-																					
-																																	if (!(this.value in this.options)) this.value = null
-																					
-																																	this.$watch('search', ((value) => {
-																																			if (!this.open || !value) return this.options = this.data
-																					
-																																			this.options = Object.keys(this.data)
-																																					.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																					.reduce((options, key) => {
-																																							options[key] = this.data[key]
-																																							return options
-																																					}, {})
-																																	}))
-																															},
-																					
-																															selectOption: function () {
-																																	if (!this.open) return this.toggleListboxVisibility()
-																					
-																																	this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																					
-																																	this.closeListbox()
-																															},
-																					
-																															toggleListboxVisibility: function () {
-																																	if (this.open) return this.closeListbox()
-																					
-																																	this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																					
-																																	if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																					
-																																	this.open = true
-																					
-																																	this.$nextTick(() => {
-																																			this.$refs.search.focus()
-																					
-																																			this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																					block: "center"
-																																			})
-																																	})
-																															},
-																													}
-																											}
-																									</script>
-																							</div>
-																					</div>
-																						<!--Fin select-->
-                                            </div>
-                                          </div>
+                                                    <label for="scale" class="block text-sm">Ansiedad al comer (escala del 1 al 10)</label>
+                                                    <select id="scale" name="scale" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>1</option>
+                                                        <option>2</option>
+                                                        <option>3</option>
+                                                        <option>4</option>
+                                                        <option>5</option>
+                                                        <option>6</option>
+                                                        <option>7</option>
+                                                        <option>8</option>
+                                                        <option>9</option>
+                                                        <option>10</option>
+                                                    </select>
+                                                </div>
+
+
                                         </div>
-													
-																			<div class="col-span-6 sm:col-span-2">
-																			
-																				<!--Select-->
-																	
-																	<div>
-																		<label id="listbox-label-place" class="text-sm">
-																				Lugar
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { casa: 'Casa', trabajo: 'Trabajo', establecimiento: 'Establecimiento'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'place', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-
-																			</div>
-																				<div class="col-span-6 sm:col-span-2	">
-																			<div>
-																		<label id="listbox-label-distracts" class="text-sm">
-																				Tipo de comida
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { preparada: 'Preparada', comprada: 'Comprada', comedor: 'Comedor de trabajo'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'distracts', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-																				</div>
-																			
-																			<div class="col-span-6 sm:col-span-6 mt-2">
-																				<label for="motive" class="text-sm">Descripción de alimentos</label>
-																				<input type="text" name="motive" id="motive" autocomplete="motive" class="placeholder">
-																		</div>
-													
-																	</div>
-															</form>
-													</div>
-											</div>
-									</div>
-
-							</div> <!-- fin card dieta habitual-->
-			</div>
-	</div>
-				<!-- Relación con los alimentos--> 
-						<div class="bg-gray-100 w-full px-6 py-5">
-							<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-									<div class="md:grid md:grid-cols-3 md:gap-6">
-											<div class="md:col-span-3">
-													<h3 >Relación con los alimentos</h3>
-													<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-											
-													<div class="mt-5 md:mt-5 md:col-span-3">
-															<form action="#" method="POST">
-																	<div class="grid grid-cols-6 gap-6">
-																			<div class="col-span-6 sm:col-span-3">
-																				
-																				<!--Select-->
-																	
-																	<div>
-																	<label id="listbox-label-distracts" class="text-sm">
-																			Distractores a la hora de comer
-																	</label>
-																	<div class="max-w-screen-2xl mt-1">
-																			<div
-																							x-data="select({ data: { tv: 'Televisión', cel: 'Celular', compu: 'Computadora'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'distracts', placeholder: 'Elige una opción' })"
-																							x-init="init()"
-																							@click.away="closeListbox()"
-																							@keydown.escape="closeListbox()"
-																							class="relative"
-																			>
-																							<span class="inline-block w-full rounded-md shadow-sm">
-																										<button type="button"
-																														x-ref="button"
-																														@click="toggleListboxVisibility()"
-																														:aria-expanded="open"
-																														aria-haspopup="listbox"
-																														class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																										>
-																													<span
-																																	x-show="! open"
-																																	x-text="value in options ? options[value] : placeholder"
-																																	:class="{ 'text-gray-500': ! (value in options) }"
-																																	class="block truncate"
-																													></span>
-															
-																													<input
-																																	x-ref="search"
-																																	x-show="open"
-																																	x-model="search"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	type="search"
-																																	class="w-full h-full form-control focus:outline-none"
-																													/>
-															
-																													<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																															<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																	<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																				stroke-linejoin="round"></path>
-																															</svg>
-																													</span>
-																										</button>
-																							</span>
-															
-																					<div
-																									x-show="open"
-																									x-transition:leave="transition ease-in duration-100"
-																									x-transition:leave-start="opacity-100"
-																									x-transition:leave-end="opacity-0"
-																									x-cloak
-																									class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																					>
-																							<ul
-																											x-ref="listbox"
-																											@keydown.enter.stop.prevent="selectOption()"
-																											@keydown.arrow-up.prevent="focusPreviousOption()"
-																											@keydown.arrow-down.prevent="focusNextOption()"
-																											role="listbox"
-																											:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																											tabindex="-1"
-																											class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																							>
-																									<template x-for="(key, index) in Object.keys(options)" :key="index">
-																											<li
-																															:id="name + 'Option' + focusedOptionIndex"
-																															@click="selectOption()"
-																															@mouseenter="focusedOptionIndex = index"
-																															@mouseleave="focusedOptionIndex = null"
-																															role="option"
-																															:aria-selected="focusedOptionIndex === index"
-																															:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																															class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																											>
-																															<span x-text="Object.values(options)[index]"
-																																		:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																		class="block font-normal truncate"
-																															></span>
-															
-																													<span
-																																	x-show="key === value"
-																																	:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																	class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																													>
-																																	<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																			<path fill-rule="evenodd"
-																																						d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																						clip-rule="evenodd"/>
-																																	</svg>
-																															</span>
-																											</li>
-																									</template>
-															
-																									<div
-																													x-show="! Object.keys(options).length"
-																													x-text="emptyOptionsMessage"
-																													class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																							</ul>
-																					</div>
-																			</div>
-															
-																			<script>
-																					function select(config) {
-																							return {
-																									data: config.data,
-															
-																									emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-															
-																									focusedOptionIndex: null,
-															
-																									name: config.name,
-															
-																									open: false,
-															
-																									options: {},
-															
-																									placeholder: config.placeholder ?? 'Select an option',
-															
-																									search: '',
-															
-																									value: config.value,
-															
-																									closeListbox: function () {
-																											this.open = false
-															
-																											this.focusedOptionIndex = null
-															
-																											this.search = ''
-																									},
-															
-																									focusNextOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-															
-																											if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-															
-																											this.focusedOptionIndex++
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									focusPreviousOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-															
-																											if (this.focusedOptionIndex <= 0) return
-															
-																											this.focusedOptionIndex--
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									init: function () {
-																											this.options = this.data
-															
-																											if (!(this.value in this.options)) this.value = null
-															
-																											this.$watch('search', ((value) => {
-																													if (!this.open || !value) return this.options = this.data
-															
-																													this.options = Object.keys(this.data)
-																															.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																															.reduce((options, key) => {
-																																	options[key] = this.data[key]
-																																	return options
-																															}, {})
-																											}))
-																									},
-															
-																									selectOption: function () {
-																											if (!this.open) return this.toggleListboxVisibility()
-															
-																											this.value = Object.keys(this.options)[this.focusedOptionIndex]
-															
-																											this.closeListbox()
-																									},
-															
-																									toggleListboxVisibility: function () {
-																											if (this.open) return this.closeListbox()
-															
-																											this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-															
-																											if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-															
-																											this.open = true
-															
-																											this.$nextTick(() => {
-																													this.$refs.search.focus()
-															
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center"
-																													})
-																											})
-																									},
-																							}
-																					}
-																			</script>
-																	</div>
-															</div>
-																<!--Fin select-->
-
-																			</div>
-													
-																			<div class="col-span-6 sm:col-span-3">
-																			
-																				<!--Select-->
-																	
-																	<div>
-																		<label id="listbox-label-distracts" class="text-sm">
-																				Ansiedad al comer (escala del 1 al 10)
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { 1: '1', 2: '2', 3: '3', 4: '4', 5: '5', 6: '6', 7: '7', 8: '8', 9: '9', 10: '10'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'distracts', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-
-																			</div>
-
-																			
-																			<div class="col-span-6 sm:col-span-6 mt-2">
-																				<label for="motive" class="text-sm">Alimento(s) que provocan preocupación, incomodidad o ansiedad</label>
-																				<input type="text" name="motive" id="motive" autocomplete="motive" class="placeholder">
-																		</div>
-																			
-																	</div>
-															</form>
-													</div>
-											</div>
-									</div>
-							</div> <!-- fin card datos generales-->
-			</div>
-
-						<!-- Frecuencia de los alimetos--> 
-						<div class="bg-gray-100 w-full px-6 py-5">
-							<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-									<div class="md:grid md:grid-cols-3 md:gap-6">
-											<div class="md:col-span-3">
-													<h3 >Frecuencia de los alimetos</h3>
-													<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-											
-													<div class="mt-5 md:mt-5 md:col-span-3">
-															<form action="#" method="POST">
-																	<div class="grid grid-cols-6 gap-6">
-																			<div class="col-span-6 sm:col-span-3">
-																				
-																				<!--Select-->
-																	
-																	<div>
-																	<label id="listbox-label-vegetables" class="text-sm">
-																			Verduras
-																	</label>
-																	<div class="max-w-screen-2xl mt-1">
-																			<div
-																							x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'distracts', placeholder: 'Elige una opción' })"
-																							x-init="init()"
-																							@click.away="closeListbox()"
-																							@keydown.escape="closeListbox()"
-																							class="relative"
-																			>
-																							<span class="inline-block w-full rounded-md shadow-sm">
-																										<button type="button"
-																														x-ref="button"
-																														@click="toggleListboxVisibility()"
-																														:aria-expanded="open"
-																														aria-haspopup="listbox"
-																														class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																										>
-																													<span
-																																	x-show="! open"
-																																	x-text="value in options ? options[value] : placeholder"
-																																	:class="{ 'text-gray-500': ! (value in options) }"
-																																	class="block truncate"
-																													></span>
-															
-																													<input
-																																	x-ref="search"
-																																	x-show="open"
-																																	x-model="search"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	type="search"
-																																	class="w-full h-full form-control focus:outline-none"
-																													/>
-															
-																													<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																															<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																	<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																				stroke-linejoin="round"></path>
-																															</svg>
-																													</span>
-																										</button>
-																							</span>
-															
-																					<div
-																									x-show="open"
-																									x-transition:leave="transition ease-in duration-100"
-																									x-transition:leave-start="opacity-100"
-																									x-transition:leave-end="opacity-0"
-																									x-cloak
-																									class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																					>
-																							<ul
-																											x-ref="listbox"
-																											@keydown.enter.stop.prevent="selectOption()"
-																											@keydown.arrow-up.prevent="focusPreviousOption()"
-																											@keydown.arrow-down.prevent="focusNextOption()"
-																											role="listbox"
-																											:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																											tabindex="-1"
-																											class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																							>
-																									<template x-for="(key, index) in Object.keys(options)" :key="index">
-																											<li
-																															:id="name + 'Option' + focusedOptionIndex"
-																															@click="selectOption()"
-																															@mouseenter="focusedOptionIndex = index"
-																															@mouseleave="focusedOptionIndex = null"
-																															role="option"
-																															:aria-selected="focusedOptionIndex === index"
-																															:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																															class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																											>
-																															<span x-text="Object.values(options)[index]"
-																																		:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																		class="block font-normal truncate"
-																															></span>
-															
-																													<span
-																																	x-show="key === value"
-																																	:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																	class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																													>
-																																	<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																			<path fill-rule="evenodd"
-																																						d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																						clip-rule="evenodd"/>
-																																	</svg>
-																															</span>
-																											</li>
-																									</template>
-															
-																									<div
-																													x-show="! Object.keys(options).length"
-																													x-text="emptyOptionsMessage"
-																													class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																							</ul>
-																					</div>
-																			</div>
-															
-																			<script>
-																					function select(config) {
-																							return {
-																									data: config.data,
-															
-																									emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-															
-																									focusedOptionIndex: null,
-															
-																									name: config.name,
-															
-																									open: false,
-															
-																									options: {},
-															
-																									placeholder: config.placeholder ?? 'Select an option',
-															
-																									search: '',
-															
-																									value: config.value,
-															
-																									closeListbox: function () {
-																											this.open = false
-															
-																											this.focusedOptionIndex = null
-															
-																											this.search = ''
-																									},
-															
-																									focusNextOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-															
-																											if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-															
-																											this.focusedOptionIndex++
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									focusPreviousOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-															
-																											if (this.focusedOptionIndex <= 0) return
-															
-																											this.focusedOptionIndex--
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									init: function () {
-																											this.options = this.data
-															
-																											if (!(this.value in this.options)) this.value = null
-															
-																											this.$watch('search', ((value) => {
-																													if (!this.open || !value) return this.options = this.data
-															
-																													this.options = Object.keys(this.data)
-																															.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																															.reduce((options, key) => {
-																																	options[key] = this.data[key]
-																																	return options
-																															}, {})
-																											}))
-																									},
-															
-																									selectOption: function () {
-																											if (!this.open) return this.toggleListboxVisibility()
-															
-																											this.value = Object.keys(this.options)[this.focusedOptionIndex]
-															
-																											this.closeListbox()
-																									},
-															
-																									toggleListboxVisibility: function () {
-																											if (this.open) return this.closeListbox()
-															
-																											this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-															
-																											if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-															
-																											this.open = true
-															
-																											this.$nextTick(() => {
-																													this.$refs.search.focus()
-															
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center"
-																													})
-																											})
-																									},
-																							}
-																					}
-																			</script>
-																	</div>
-															</div>
-																<!--Fin select-->
-
-																			</div>
-													
-																			<div class="col-span-6 sm:col-span-3">
-																			
-																				<!--Select-->
-																	
-																	<div>
-																		<label id="listbox-label-fruits" class="text-sm">
-																				Frutas
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'distracts', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-
-																				</div>
-
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-cereals" class="text-sm">
-																				Cereales y Tuberculos
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'cereals', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-legums" class="text-sm">
-																					Leguminosas
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'legums', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-beef" class="text-sm">
-																				Carne de res
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'beef', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-chicken" class="text-sm">
-																					Pollo
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'chicken', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-fish" class="text-sm">
-																				Pescados y mariscos
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'fish', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-pork" class="text-sm">
-																					Carne de cerdo
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'pork', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-sausages" class="text-sm">
-																				Embutidos
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'sausages', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-egg" class="text-sm">
-																					Huevo
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'egg', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-milk" class="text-sm">
-																				Leche
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'milk', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-milk-type" class="text-sm">
-																					Tipo de Leche
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { entera: 'Entera', descremada: 'Descremada (light)', semidescremada: 'Semidescremada', deslactosada: 'Deslactosada', lechadas: 'Lechadas (almendras, coco)'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'milk-type', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-yogurt" class="text-sm">
-																				Yogurt
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'yogurt', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-cheese" class="text-sm">
-																					Queso
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'cheese', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-nuts" class="text-sm">
-																				Nueces y semillas
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nuts', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-coffe" class="text-sm">
-																					Café
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'coffe', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-sugary-drinks" class="text-sm">
-																				Bebidas azucaradas
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'sugary-drinks', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																				<div class="col-span-6 sm:col-span-3">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																			<label id="listbox-label-snacks" class="text-sm">
-																					Botanas
-																			</label>
-																			<div class="max-w-screen-2xl mt-1">
-																					<div
-																									x-data="select({ data: { diariamente: 'Diariamente', uno: '1 - 2 veces a la semana', tres: '3 - 5 veces a la semana', mes: '1 - 2 veces al mes', nunca: 'Nunca'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'snacks', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																		<!--Fin select-->
-		
-	
-																				</div>
-																				<div class="col-span-6 sm:col-span-6">
-																				
-																					<!--Select-->
-																		
-																		<div>
-																		<label id="listbox-label-water" class="text-sm">
-																			Consumo de agua natural al día 
-																		</label>
-																		<div class="max-w-screen-2xl mt-1">
-																				<div
-																								x-data="select({ data: { menos: 'Menos de un litro', uno: 'De 1 a 2 litros', mas: 'Más de 2 litros', sin: 'Sin registro'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'water', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																	<!--Fin select-->
-	
-																				</div>
-														
-																					
-																			
-																	</div>
-															</form>
-													</div>
-											</div>
-									</div>
-							</div> <!-- fin card datos generales-->
-			</div>
 
 
+                                        <div class="col-span-6 sm:col-span-6 mt-2">
+                                            <label for="motive" class="text-sm">Alimento(s) que provocan preocupación,
+                                                incomodidad o ansiedad</label>
+                                            <input type="text" name="motive" id="motive" autocomplete="motive"
+                                                class="placeholder">
+                                        </div>
 
-              <!-- /End replace -->
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin card datos generales-->
             </div>
-          </div>
+
+            <!-- Frecuencia de los alimetos-->
+            <div class="bg-gray-100 w-full px-6 py-5">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3>Frecuencia de los alimetos</h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+
+                            <div class="mt-5 md:mt-5 md:col-span-3">
+                                <form action="#" method="POST">
+                                    <div class="grid grid-cols-6 gap-6">
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="vegetables" class="block text-sm"> Verduras </label>
+                                                    <select id="vegetables" name="vegetables" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="fruits" class="block text-sm"> Frutas </label>
+                                                    <select id="fruits" name="fruits" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="cereals" class="block text-sm"> Cereales y Tuberculos  </label>
+                                                    <select id="cereals" name="cereals" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                           <div>
+                                                    <label for="legums" class="block text-sm"> Leguminosas  </label>
+                                                    <select id="legums" name="legums" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="beef" class="block text-sm"> Carne de res  </label>
+                                                    <select id="beef" name="beef" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="chicken" class="block text-sm"> Pollo  </label>
+                                                    <select id="chicken" name="chicken" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="fish" class="block text-sm"> Pescados y mariscos  </label>
+                                                    <select id="fish" name="fish" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="pork" class="block text-sm"> Carne de cerdo  </label>
+                                                    <select id="pork" name="pork" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="sausages" class="block text-sm"> Embutidos  </label>
+                                                    <select id="sausages" name="sausages" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="egg" class="block text-sm"> Huevo  </label>
+                                                    <select id="egg" name="egg" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="milk" class="block text-sm"> Leche  </label>
+                                                    <select id="milk" name="milk" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="milk-type" class="block text-sm"> Tipo de leche  </label>
+                                                    <select id="milk-type" name="milk-type" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Entera</option>
+                                                        <option>Descremada (Light)</option>
+                                                        <option>Semidescremada</option>
+                                                        <option>Deslactosada</option>
+                                                        <option>Lechadas (almendras, coco)</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="yogurt" class="block text-sm"> Yogurt  </label>
+                                                    <select id="yogurt" name="yogurt" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="chesee" class="block text-sm"> Queso  </label>
+                                                    <select id="chesee" name="chesee" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="nuts" class="block text-sm"> Nueces y semillas  </label>
+                                                    <select id="nuts" name="nuts" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="coffe" class="block text-sm"> Café  </label>
+                                                    <select id="coffe" name="cofee" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="sugary-drinks" class="block text-sm"> Bebidas azucaradas  </label>
+                                                    <select id="sugary-drinks" name="sugary-drinks" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+                                        <div class="col-span-6 sm:col-span-3">
+
+                                            <div>
+                                                    <label for="snacks" class="block text-sm"> Botanas  </label>
+                                                    <select id="snacks" name="snacks" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Diariamente</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>1-2 veces al mes</option>
+                                                        <option>Nunca</option>
+                                                    </select>
+                                                </div>
+
+
+                                        </div>
+                                        <div class="col-span-6 sm:col-span-6">
+
+                                            <div>
+                                                    <label for="water" class="block text-sm"> Consumo de agua natural al día   </label>
+                                                    <select id="water" name="water" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Menos de un litro</option>
+                                                        <option>De 1-2 litros</option>
+                                                        <option>Más de 2 litros</option>
+                                                        <option>Sin registro</option>
+                                                    </select>
+                                                </div>
+
+                                        </div>
+
+
+
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div> <!-- fin card datos generales-->
+            </div>
+
+
+
+            <!-- /End replace -->
         </div>
-      </div>
     </div>
-  </div>
+    </div>
+    </div>
+    </div>
+    </div>
+    
+    </div>
+</turbo-frame>

--- a/app/views/patients/historials/new.html.erb
+++ b/app/views/patients/historials/new.html.erb
@@ -1,1987 +1,883 @@
-<div class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog" aria-modal="true">
-    <div class="absolute inset-0 overflow-hidden">
-      <!--
-        Background overlay, show/hide based on slide-over state.
-  
-        Entering: "ease-in-out duration-500"
-          From: "opacity-0"
-          To: "opacity-100"
-        Leaving: "ease-in-out duration-500"
-          From: "opacity-100"
-          To: "opacity-0"
-      -->
-      <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-      <div class="fixed inset-y-0 right-0 pl-10 max-w-full flex">
-        <!--
-          Slide-over panel, show/hide based on slide-over state.
-  
-          Entering: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-full"
-            To: "translate-x-0"
-          Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-0"
-            To: "translate-x-full"
-        -->
-        <div class="relative w-screen max-w-3xl">
-          <!--
-            Close button, show/hide based on slide-over state.
-  
-            Entering: "ease-in-out duration-500"
-              From: "opacity-0"
-              To: "opacity-100"
-            Leaving: "ease-in-out duration-500"
-              From: "opacity-100"
-              To: "opacity-0"
-          -->
-          <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
-            <button type="button" class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
-              <span class="sr-only">Close panel</span>
-              <!-- Heroicon name: outline/x -->
-              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-  
-          <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
-            <div class="px-4 sm:px-6 mt-4">
-                <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
-                    Expediente
-                </h2>
-                <div class="mt-5">
-                    <div class="sm:hidden">
-                    <label for="tabs" class="sr-only">Select a tab</label>
-                    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-                    <select id="tabs" name="tabs" class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md">
-                        <option>Generales</option>
-                
-                        <option selected>Historial</option>
+<turbo-frame data-controller="operation-tabs-shower" data-operation-tabs-shower-target="turboFrame"
+    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame" id="history">
 
-												<option>Antropométrico</option>
-                
-                        <option>Hábitos</option>
-                
-                        <option>Actividad física</option>
 
-                        <option>Notas</option>
-                    </select>
+    <div class="mt-2 relative flex-1 overflow-y-auto">
+        <!-- Replace with your content -->
+        <div class="bg-gray-100 w-full px-6 py-5">
+            <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                <div class="md:grid md:grid-cols-3 md:gap-6">
+                    <div class="md:col-span-3">
+                        <h3>Antecedentes personales patológicos </h3>
+                        <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+
+                        <div class="mt-3 md:mt-3 md:col-span-3">
+                            <fieldset>
+                                <legend class="text-base font-medium text-gray-900"></legend>
+                                <div class="ml-3 text-md">
+                                    <h4>Enfermedades</h4>
+                                </div>
+                                <div class="grid grid-cols-2 mt-4">
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="ninguna" name="ninguna" class="checkbox" />
+                                            Ninguna
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="diabetes1" name="diabetes1" class="checkbox" />
+                                            Diabetes tipo I
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="diabetes2" name="diabetes2" class="checkbox" />
+                                            Diabetes tipo II
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="gestational" name="gestational"
+                                                class="checkbox" />
+                                            Diabetes gestacional
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="hypertension" name="hypertension"
+                                                class="checkbox" />
+                                            Hipertensión arterial
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="cholesterol" name="cholesterol"
+                                                class="checkbox" />
+                                            Colesterol elevado
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="triglycerides" name="triglycerides"
+                                                class="checkbox" />
+                                            Trigliceridos elevados
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="cardiovascular" name="cardiovascular"
+                                                class="checkbox" />
+                                            Enfermedad cardiovascular
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="overweight" name="overweight" class="checkbox" />
+                                            Sobrepeso
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="obesity" name="obesity" class="checkbox" />
+                                            Obesidad
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="cancer" name="cancer" class="checkbox" />
+                                            Cáncer
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="hypotheroidism" name="hypotheroidism"
+                                                class="checkbox" />
+                                            Hipotiroidismo
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="syndrome" name="syndrome" class="checkbox" />
+                                            Síndrome de Ovario Poliquistico
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="anemia" name="anemia" class="checkbox" />
+                                            Anemia
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="depression" name="depression" class="checkbox" />
+                                            Depresión
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="anxiety" name="anxiety" class="checkbox" />
+                                            Ansiedad
+                                        </label>
+                                    </div>
+                                    <div class="mt-4">
+                                        <label class="medium">
+                                            <input type="checkbox" id="disroders" name="disroders" class="checkbox" />
+                                            Trastornos psicológicos
+                                        </label>
+                                    </div>
+                                </div>
+
+
+
+                            </fieldset>
+                            <div class="col-span-6 sm:col-span-4 mt-8">
+
+                                <div class="mt-3 md:mt-3 md:col-span-3">
+                                    <label for="other_sick" class="text-sm">Otra enfermedad</label>
+                                    <input type="text" name="motive" id="motive" autocomplete="motive"
+                                        class="dropdown sm:text-md">
+                                </div>
+                                <div class="col-span-6 sm:col-span-4 mt-8">
+                                    <div class="mt-3 md:mt-3 md:col-span-3">
+                                        <label for="medication" class="text-sm">Medicamento</label>
+
+                                        <input type="text" name="medication" id="medication" autocomplete="medication"
+                                            class="dropdown sm:text-md">
+                                    </div>
+                                    <div class="grid grid-cols-6 gap-6">
+                                    </div>
+                                    <!--Select-->
+
+                                    <div class="col-span-6 sm:col-span-6 mt-8">
+                                        <div>
+                                            <label for="cirugia" class="block text-sm ">Cirugía </label>
+                                            <select id="cirugia" name="cirugia" placeholder="Elige una opción" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                <option disabled selected>Elige una opción</option>
+                                                <option>Si</option>
+                                                <option>No</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <!--Fin Select-->
+
+                                        <div class="ml-3 text-md mt-8">
+                                            <h4>Trastornos gastrointestinales</h4>
+                                        </div>
+                                        <div class="grid grid-cols-3 mt-4">
+
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="nausea" name="nausea"
+                                                        class="input-checkbox" />
+                                                    Nauseas
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="vomito" name="vomito"
+                                                        class="input-checkbox" />
+                                                    Vómitos
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="diarrhea" name="diarrhea"
+                                                        class="input-checkbox" />
+                                                    Diarrea
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="estrenimiento" name="estrenimiento"
+                                                        class="input-checkbox" />
+                                                    Estreñimiento
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="inflammation" name="inflammation"
+                                                        class="input-checkbox" />
+                                                    Inflamación abdominal
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="colitis" name="colitis"
+                                                        class="input-checkbox" />
+                                                    Colitis
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="gastritis" name="gastritis"
+                                                        class="input-checkbox" />
+                                                    Gastritis
+                                                </label>
+                                            </div>
+                                            <div class="mt-4">
+                                                <label class="medium">
+                                                    <input type="checkbox" id="reflux" name="reflux"
+                                                        class="input-checkbox" />
+                                                    Reflujo
+                                                </label>
+                                            </div>
+                                        </div>
+
+                                        </fieldset>
+                                        <div class="col-span-6 sm:col-span-4 mt-8">
+                                            <label for="motive" class="text-sm">Otro trastorno gastrointestinal</label>
+                                            <input type="text" name="motive" id="motive" autocomplete="motive"
+                                                class="dropdown sm:text-md">
+                                        </div>
+
+                                    </div>
+                                </div> <!-- fin card Motivo de consulta-->
+
+                            </div>
+
+                            <!-- /End replace -->
+                        </div>
+
                     </div>
-                    <div class="hidden sm:block">
-                    <nav class="flex space-x-4" aria-label="Tabs">
-                        <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
-                        <a href="general" class="text-gray-500  hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Generales
-                        </a>
 
-                        <a href="history" class= "bg-indigo-100 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md" aria-current="page">
-                        Historial
-                        </a>
+                </div>
 
-												<a href="anthropometric" class=" text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Antropométrico
-                        </a>
-                
-                        <a href="habits" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Hábitos
-                        </a>
+            </div>
+        </div>
 
-                        <a href="physical_activity" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Actividad física
-                        </a>
-                
-                        <a href="notes" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Notas
-                        </a>
-                    </nav>
+        <!-- Exploración físico -->
+        <div class="bg-gray-100 w-full px-6 py-5">
+            <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                <div class="md:grid md:grid-cols-3 md:gap-6">
+                    <div class="md:col-span-3">
+                        <h3 class="text-lg font-medium leading-6 text-gray-900">Exploración física / Signos y síntomas
+                        </h3>
+                        <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+
+                        <div class="mt-5 md:mt-5 md:col-span-3">
+                            <form action="#" method="POST">
+                                <div class="grid grid-cols-6 gap-6">
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <label for="hair" class="text-sm">Cabello</label>
+                                        <input type="text" name="hair" id="hair" autocomplete="hair"
+                                            class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
+                                    </div>
+
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <label for="skin" class="text-sm">Piel</label>
+                                        <input type="text" name="skin" id="skin" autocomplete="skin"
+                                            class="dropdown sm:text-md">
+                                    </div>
+
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <label for="eyes" class="text-sm">Ojos</label>
+                                        <input type="text" name="eyes" id="eyes" autocomplete="eyes"
+                                            class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
+                                    </div>
+
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <label for="nails" class="text-sm">Uñas</label>
+                                        <input type="text" name="nails" id="nails" autocomplete="nails"
+                                            class="dropdown sm:text-md">
+                                    </div>
+
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <label for="mouth" class="text-sm">Boca</label>
+                                        <input type="text" name="mouth" id="mouth" autocomplete="mouth"
+                                            class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
+                                    </div>
+
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <label for="blood-pressure" class="text-sm">Presión arterial (mm Hg)</label>
+                                        <input type="text" name="blood-pressure" id="blood-pressure"
+                                            autocomplete="blood-pressure" class="dropdown sm:text-md">
+                                    </div>
+
+
+                                                </div>
+                                            </div>
+
+
+                                        </div>
+                            </form>
+                        </div>
                     </div>
                 </div>
-  
-            </div>
-						
-             <div class="mt-2 relative flex-1 overflow-y-auto">
-              <!-- Replace with your content --> 
-            <div class="bg-gray-100 w-full px-6 py-5">
-                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-                    <div class="md:grid md:grid-cols-3 md:gap-6">
-                        <div class="md:col-span-3">
-                            <h3>Antecedentes personales patológicos </h3>
-                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                        
-                            <div class="mt-3 md:mt-3 md:col-span-3">
-                                <fieldset>
-                                    <legend class="text-base font-medium text-gray-900"></legend>
-																		<div class="ml-3 text-md">
-																			<h4 >Enfermedades</h4>
-																			</div>
-																			<div class="grid grid-cols-2 mt-4">
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="ninguna" name="ninguna" class="checkbox"/>
-																						Ninguna
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="diabetes1" name="diabetes1" class="checkbox"/>
-																						Diabetes tipo I
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="diabetes2" name="diabetes2" class="checkbox"/>
-																						Diabetes tipo II
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="gestational" name="gestational" class="checkbox"/>
-																						Diabetes gestacional 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="hypertension" name="hypertension" class="checkbox"/>
-																						Hipertensión arterial 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="cholesterol" name="cholesterol" class="checkbox"/>
-																						Colesterol elevado
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="triglycerides" name="triglycerides" class="checkbox"/>
-																						Trigliceridos elevados
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="cardiovascular" name="cardiovascular" class="checkbox"/>
-																						Enfermedad cardiovascular 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="overweight" name="overweight" class="checkbox"/>
-																						Sobrepeso
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="obesity" name="obesity" class="checkbox"/>
-																						Obesidad 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="cancer" name="cancer" class="checkbox"/>
-																						Cáncer
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="hypotheroidism" name="hypotheroidism" class="checkbox"/>
-																						Hipotiroidismo
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="syndrome" name="syndrome" class="checkbox"/>
-																						Síndrome de Ovario Poliquistico 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="anemia" name="anemia" class="checkbox"/>
-																						Anemia
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="depression" name="depression" class="checkbox"/>
-																						Depresión 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="anxiety" name="anxiety" class="checkbox"/>
-																						Ansiedad 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="disroders" name="disroders" class="checkbox"/>
-																						Trastornos psicológicos 
-																					</label>
-																				</div>
-																			</div>
-																			
-                                     
-                                   
-                                </fieldset>
-                                <div class="col-span-6 sm:col-span-4 mt-8">
+            </div> <!-- fin card exploración-->
 
-																	<div class="mt-3 md:mt-3 md:col-span-3">
-                                    <label for="other_sick" class="text-sm">Otra enfermedad</label> 
-                                    <input type="text" name="motive" id="motive" autocomplete="motive" class="dropdown sm:text-md">
-                                </div>
-																<div class="col-span-6 sm:col-span-4 mt-8">
-																<div class="mt-3 md:mt-3 md:col-span-3">
-                                    <label for="medication" class="text-sm">Medicamento</label> 
-                                
-																	<input type="text" name="medication" id="medication" autocomplete="medication" class="dropdown sm:text-md">
-																	</div>
-																	<div class="grid grid-cols-6 gap-6">
-																		</div>
-																<!--Select-->
-																	
-																<div class="col-span-6 sm:col-span-6 mt-8">
-																	<div>
-																	<label id="listbox-label" class="text-sm">
-																			Cirugía
-																	</label>
-																	<div class="max-w-xs mt-1">
-																			<div
-																							x-data="select({ data: { s: 'Si', n: 'No'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'cirugia', placeholder: 'Elige una opción' })"
-																							x-init="init()"
-																							@click.away="closeListbox()"
-																							@keydown.escape="closeListbox()"
-																							class="relative"
-																			>
-																							<span class="inline-block w-full rounded-md shadow-sm">
-																										<button type="button"
-																														x-ref="button"
-																														@click="toggleListboxVisibility()"
-																														:aria-expanded="open"
-																														aria-haspopup="listbox"
-																														class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																										>
-																													<span
-																																	x-show="! open"
-																																	x-text="value in options ? options[value] : placeholder"
-																																	:class="{ 'text-gray-500': ! (value in options) }"
-																																	class="block truncate"
-																													></span>
-															
-																													<input
-																																	x-ref="search"
-																																	x-show="open"
-																																	x-model="search"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	type="search"
-																																	class="w-full h-full form-control focus:outline-none"
-																													/>
-															
-																													<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																															<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																	<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																				stroke-linejoin="round"></path>
-																															</svg>
-																													</span>
-																										</button>
-																							</span>
-															
-																					<div
-																									x-show="open"
-																									x-transition:leave="transition ease-in duration-100"
-																									x-transition:leave-start="opacity-100"
-																									x-transition:leave-end="opacity-0"
-																									x-cloak
-																									class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																					>
-																							<ul
-																											x-ref="listbox"
-																											@keydown.enter.stop.prevent="selectOption()"
-																											@keydown.arrow-up.prevent="focusPreviousOption()"
-																											@keydown.arrow-down.prevent="focusNextOption()"
-																											role="listbox"
-																											:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																											tabindex="-1"
-																											class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																							>
-																									<template x-for="(key, index) in Object.keys(options)" :key="index">
-																											<li
-																															:id="name + 'Option' + focusedOptionIndex"
-																															@click="selectOption()"
-																															@mouseenter="focusedOptionIndex = index"
-																															@mouseleave="focusedOptionIndex = null"
-																															role="option"
-																															:aria-selected="focusedOptionIndex === index"
-																															:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																															class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																											>
-																															<span x-text="Object.values(options)[index]"
-																																		:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																		class="block font-normal truncate"
-																															></span>
-															
-																													<span
-																																	x-show="key === value"
-																																	:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																	class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																													>
-																																	<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																			<path fill-rule="evenodd"
-																																						d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																						clip-rule="evenodd"/>
-																																	</svg>
-																															</span>
-																											</li>
-																									</template>
-															
-																									<div
-																													x-show="! Object.keys(options).length"
-																													x-text="emptyOptionsMessage"
-																													class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																							</ul>
-																					</div>
-																			</div>
-															
-																			<script>
-																					function select(config) {
-																							return {
-																									data: config.data,
-															
-																									emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-															
-																									focusedOptionIndex: null,
-															
-																									name: config.name,
-															
-																									open: false,
-															
-																									options: {},
-															
-																									placeholder: config.placeholder ?? 'Select an option',
-															
-																									search: '',
-															
-																									value: config.value,
-															
-																									closeListbox: function () {
-																											this.open = false
-															
-																											this.focusedOptionIndex = null
-															
-																											this.search = ''
-																									},
-															
-																									focusNextOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-															
-																											if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-															
-																											this.focusedOptionIndex++
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									focusPreviousOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-															
-																											if (this.focusedOptionIndex <= 0) return
-															
-																											this.focusedOptionIndex--
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									init: function () {
-																											this.options = this.data
-															
-																											if (!(this.value in this.options)) this.value = null
-															
-																											this.$watch('search', ((value) => {
-																													if (!this.open || !value) return this.options = this.data
-															
-																													this.options = Object.keys(this.data)
-																															.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																															.reduce((options, key) => {
-																																	options[key] = this.data[key]
-																																	return options
-																															}, {})
-																											}))
-																									},
-															
-																									selectOption: function () {
-																											if (!this.open) return this.toggleListboxVisibility()
-															
-																											this.value = Object.keys(this.options)[this.focusedOptionIndex]
-															
-																											this.closeListbox()
-																									},
-															
-																									toggleListboxVisibility: function () {
-																											if (this.open) return this.closeListbox()
-															
-																											this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-															
-																											if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-															
-																											this.open = true
-															
-																											this.$nextTick(() => {
-																													this.$refs.search.focus()
-															
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center"
-																													})
-																											})
-																									},
-																							}
-																					}
-																			</script>
-																	</div>
-															</div>
-																<!--Fin select-->
-																<div class="ml-3 text-md mt-8">
-																	<h4>Trastornos gastrointestinales</h4>
-																	</div>
-																	<div class="grid grid-cols-3 mt-4">
-																	
-																			<div class="mt-4">
-																				<label  class="medium">
-																					<input type="checkbox" id="nausea" name="nausea" class="input-checkbox"/>
-																					Nauseas
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label  class="medium">
-																					<input type="checkbox" id="vomito" name="vomito" class="input-checkbox"/>
-																					Vómitos
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label  class="medium">
-																					<input type="checkbox" id="diarrhea" name="diarrhea" class="input-checkbox"/>
-																					Diarrea
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label  class="medium">
-																					<input type="checkbox" id="estrenimiento" name="estrenimiento" class="input-checkbox"/>
-																					Estreñimiento  
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label  class="medium">
-																					<input type="checkbox" id="inflammation" name="inflammation" class="input-checkbox"/>
-																					Inflamación abdominal  
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label class="medium">
-																					<input type="checkbox" id="colitis" name="colitis" class="input-checkbox"/>
-																					Colitis 
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label class="medium">
-																					<input type="checkbox" id="gastritis" name="gastritis" class="input-checkbox"/>
-																					Gastritis 
-																				</label>
-																			</div>
-																			<div class="mt-4">
-																				<label class="medium">
-																					<input type="checkbox" id="reflux" name="reflux" class="input-checkbox"/>
-																					Reflujo 
-																				</label>
-																			</div>
-																		</div>
-																	
-																	
-																 
-															 
-														</fieldset>
-														<div class="col-span-6 sm:col-span-4 mt-8">
-																<label for="motive" class="text-sm">Otro trastorno gastrointestinal</label>
-																<input type="text" name="motive" id="motive" autocomplete="motive" class="dropdown sm:text-md">
-														</div>
-												
-                    </div>
-                </div> <!-- fin card Motivo de consulta-->
-								
-            </div>
-							
-              <!-- /End replace -->
-            </div>
-						
-          </div>
-					
+
+
         </div>
-				
-      </div>
-			</div>
 
-			<!-- Exploración físico --> 
-			<div class="bg-gray-100 w-full px-6 py-5">
-				<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-						<div class="md:grid md:grid-cols-3 md:gap-6">
-								<div class="md:col-span-3">
-										<h3 class="text-lg font-medium leading-6 text-gray-900">Exploración física / Signos y síntomas </h3>
-										<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-								
-										<div class="mt-5 md:mt-5 md:col-span-3">
-												<form action="#" method="POST">
-														<div class="grid grid-cols-6 gap-6">
-																<div class="col-span-6 sm:col-span-3">
-																<label for="hair" class="text-sm">Cabello</label>
-																<input type="text" name="hair" id="hair" autocomplete="hair" class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
-																</div>
-										
-																<div class="col-span-6 sm:col-span-3">
-																<label for="skin" class="text-sm">Piel</label>
-																<input type="text" name="skin" id="skin" autocomplete="skin" class="dropdown sm:text-md">
-																</div>
+        <!-- Replace with your content -->
+        <div class="bg-gray-100 w-full px-6 py-5">
+            <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                <div class="md:grid md:grid-cols-3 md:gap-6">
+                    <div class="md:col-span-3">
+                        <h3 class="text-lg font-medium leading-6 text-gray-900">Toxicomanias </h3>
+                        <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
 
-																<div class="col-span-6 sm:col-span-3">
-																<label for="eyes" class="text-sm">Ojos</label>
-																<input type="text" name="eyes" id="eyes" autocomplete="eyes" class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
-																</div>
-											
-																<div class="col-span-6 sm:col-span-3">
-																<label for="nails" class="text-sm">Uñas</label>
-																<input type="text" name="nails" id="nails" autocomplete="nails" class="dropdown sm:text-md">
-																</div>
+                        <div class="mt-5 md:mt-5 md:col-span-3">
+                            <form action="#" method="POST">
+                                <div class="grid grid-cols-6 gap-6">
+                                    <div class="col-span-6 sm:col-span-3">
+                                        <!--Select-->
+                                        <div class="col-span-6 sm:col-span-6 mt-8">
+                                            <div>
+                                                <label for="alcohol " class="block text-sm ">Alcohol </label>
+                                                <select id="alcohol " name="alcohol " class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                    <option disabled selected>Elige una opción</option>
+                                                    <option>Nunca</option>
+                                                    <option>1-2 días de la semana</option>
+                                                    <option>3-5 días de la semana</option>
+                                                    <option>Diariamente</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                        <!--Fin Select-->
+                                        <br>
+                                        <div class="col-span-6 sm:col-span-3">
+                                            <!--Select-->
+                                            <div class="col-span-6 sm:col-span-6 mt-8">
+                                                <div>
+                                                    <label for="tabaco " class="block text-sm ">Tabaco</label>
+                                                    <select id="tabaco " name="tabaco " class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Nunca</option>
+                                                        <option>1-2 días de la semana</option>
+                                                        <option>3-5 días de la semana</option>
+                                                        <option>Diariamente</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                            <!--Fin Select-->
+                                            </div>
 
-																<div class="col-span-6 sm:col-span-3">
-																<label for="mouth" class="text-sm">Boca</label>
-																<input type="text" name="mouth" id="mouth" autocomplete="mouth" class="mt-1 p-2 focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border border-gray-300 rounded-md">
-																</div>
-											
-																<div class="col-span-6 sm:col-span-3">
-																<label for="blood-pressure" class="text-sm">Presión arterial (mm Hg)</label>
-																<input type="text" name="blood-pressure" id="blood-pressure" autocomplete="blood-pressure" class="dropdown sm:text-md">
-																</div>
-										
-																
-														</div>
-												</form>
-										</div>
-								</div>
-						</div>
-				</div> <!-- fin card exploración-->
+                                                    <div x-show="! Object.keys(options).length"
+                                                        x-text="emptyOptionsMessage"
+                                                        class="px-3 py-2 text-gray-900 cursor-default select-none">
+                                                    </div>
+                                                </ul>
+                                            </div>
+                                        </div>
+
+                                        </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div> <!-- fin card información personal-->
 
 
-				
+
+        </div>
+
     </div>
-			
-			<!-- Replace with your content --> 
-			<div class="bg-gray-100 w-full px-6 py-5">
-				<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-						<div class="md:grid md:grid-cols-3 md:gap-6">
-								<div class="md:col-span-3">
-										<h3 class="text-lg font-medium leading-6 text-gray-900">Toxicomanias </h3>
-										<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-								
-										<div class="mt-5 md:mt-5 md:col-span-3">
-												<form action="#" method="POST">
-														<div class="grid grid-cols-6 gap-6">
-															<div class="col-span-6 sm:col-span-3">
-																<div>
-																<label id="listbox-label-alcohol" class="text-sm">
-																		Alcohol
-																</label>
-																<div class="max-w-xs mt-1">
-																		<div
-																		x-data="select({ data: { n: 'Nunca', n1: '1-2 días de la semana', n2: '3-5 días de la semana', d:'Diariamente'}, emptyOptionsMessage: 'No se ha seleccionado ninguna opción.', name: 'alcohol', placeholder: 'Elige una opción' })"
-																						x-init="init()"
-																						@click.away="closeListbox()"
-																						@keydown.escape="closeListbox()"
-																						class="relative"
-																		>
-																						<span class="inline-block w-full rounded-md shadow-sm">
-																									<button type="button"
-																													x-ref="button"
-																													@click="toggleListboxVisibility()"
-																													:aria-expanded="open"
-																													aria-haspopup="listbox"
-																													class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																									>
-																												<span
-																																x-show="! open"
-																																x-text="value in options ? options[value] : placeholder"
-																																:class="{ 'text-gray-500': ! (value in options) }"
-																																class="block truncate"
-																												></span>
-														
-																												<input
-																																x-ref="search"
-																																x-show="open"
-																																x-model="search"
-																																@keydown.enter.stop.prevent="selectOption()"
-																																@keydown.arrow-up.prevent="focusPreviousOption()"
-																																@keydown.arrow-down.prevent="focusNextOption()"
-																																type="search"
-																																class="w-full h-full form-control focus:outline-none"
-																												/>
-														
-																												<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																														<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																			stroke-linejoin="round"></path>
-																														</svg>
-																												</span>
-																									</button>
-																						</span>
-														
-																				<div
-																								x-show="open"
-																								x-transition:leave="transition ease-in duration-100"
-																								x-transition:leave-start="opacity-100"
-																								x-transition:leave-end="opacity-0"
-																								x-cloak
-																								class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																				>
-																						<ul
-																										x-ref="listbox"
-																										@keydown.enter.stop.prevent="selectOption()"
-																										@keydown.arrow-up.prevent="focusPreviousOption()"
-																										@keydown.arrow-down.prevent="focusNextOption()"
-																										role="listbox"
-																										:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																										tabindex="-1"
-																										class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																						>
-																								<template x-for="(key, index) in Object.keys(options)" :key="index">
-																										<li
-																														:id="name + 'Option' + focusedOptionIndex"
-																														@click="selectOption()"
-																														@mouseenter="focusedOptionIndex = index"
-																														@mouseleave="focusedOptionIndex = null"
-																														role="option"
-																														:aria-selected="focusedOptionIndex === index"
-																														:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																														class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																										>
-																														<span x-text="Object.values(options)[index]"
-																																	:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																	class="block font-normal truncate"
-																														></span>
-														
-																												<span
-																																x-show="key === value"
-																																:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																												>
-																																<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																		<path fill-rule="evenodd"
-																																					d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																					clip-rule="evenodd"/>
-																																</svg>
-																														</span>
-																										</li>
-																								</template>
-														
-																								<div
-																												x-show="! Object.keys(options).length"
-																												x-text="emptyOptionsMessage"
-																												class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																						</ul>
-																				</div>
-																		</div>
-														
-																		<script>
-																				function select(config) {
-																						return {
-																								data: config.data,
-														
-																								emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-														
-																								focusedOptionIndex: null,
-														
-																								name: config.name,
-														
-																								open: false,
-														
-																								options: {},
-														
-																								placeholder: config.placeholder ?? 'Select an option',
-														
-																								search: '',
-														
-																								value: config.value,
-														
-																								closeListbox: function () {
-																										this.open = false
-														
-																										this.focusedOptionIndex = null
-														
-																										this.search = ''
-																								},
-														
-																								focusNextOption: function () {
-																										if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-														
-																										if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-														
-																										this.focusedOptionIndex++
-														
-																										this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																												block: "center",
-																										})
-																								},
-														
-																								focusPreviousOption: function () {
-																										if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-														
-																										if (this.focusedOptionIndex <= 0) return
-														
-																										this.focusedOptionIndex--
-														
-																										this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																												block: "center",
-																										})
-																								},
-														
-																								init: function () {
-																										this.options = this.data
-														
-																										if (!(this.value in this.options)) this.value = null
-														
-																										this.$watch('search', ((value) => {
-																												if (!this.open || !value) return this.options = this.data
-														
-																												this.options = Object.keys(this.data)
-																														.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																														.reduce((options, key) => {
-																																options[key] = this.data[key]
-																																return options
-																														}, {})
-																										}))
-																								},
-														
-																								selectOption: function () {
-																										if (!this.open) return this.toggleListboxVisibility()
-														
-																										this.value = Object.keys(this.options)[this.focusedOptionIndex]
-														
-																										this.closeListbox()
-																								},
-														
-																								toggleListboxVisibility: function () {
-																										if (this.open) return this.closeListbox()
-														
-																										this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-														
-																										if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-														
-																										this.open = true
-														
-																										this.$nextTick(() => {
-																												this.$refs.search.focus()
-														
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center"
-																												})
-																										})
-																								},
-																						}
-																				}
-																		</script>
-																</div>
-														</div>
-														<br>
-														<div class="col-span-6 sm:col-span-3">
-															<div>
-															<label id="listbox-label-tobacco" class="text-sm">
-																	Tabaco
-															</label>
-															<div class="max-w-xs mt-1">
-																	<div
-																					x-data="select({ data: { n: 'Nunca', n1: '1-2 días de la semana', n2: '3-5 días de la semana', d:'Diariamente'}, emptyOptionsMessage: 'No se ha seleccionado ninguna opción.', name: 'Tabaco', placeholder: 'Elige una opción' })"
-																					x-init="init()"
-																					@click.away="closeListbox()"
-																					@keydown.escape="closeListbox()"
-																					class="relative"
-																	>
-																					<span class="inline-block w-full rounded-md shadow-sm">
-																								<button type="button"
-																												x-ref="button"
-																												@click="toggleListboxVisibility()"
-																												:aria-expanded="open"
-																												aria-haspopup="listbox"
-																												class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																								>
-																											<span
-																															x-show="! open"
-																															x-text="value in options ? options[value] : placeholder"
-																															:class="{ 'text-gray-500': ! (value in options) }"
-																															class="block truncate"
-																											></span>
-													
-																											<input
-																															x-ref="search"
-																															x-show="open"
-																															x-model="search"
-																															@keydown.enter.stop.prevent="selectOption()"
-																															@keydown.arrow-up.prevent="focusPreviousOption()"
-																															@keydown.arrow-down.prevent="focusNextOption()"
-																															type="search"
-																															class="w-full h-full form-control focus:outline-none"
-																											/>
-													
-																											<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																													<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																															<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																		stroke-linejoin="round"></path>
-																													</svg>
-																											</span>
-																								</button>
-																					</span>
-													
-																			<div
-																							x-show="open"
-																							x-transition:leave="transition ease-in duration-100"
-																							x-transition:leave-start="opacity-100"
-																							x-transition:leave-end="opacity-0"
-																							x-cloak
-																							class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																			>
-																					<ul
-																									x-ref="listbox"
-																									@keydown.enter.stop.prevent="selectOption()"
-																									@keydown.arrow-up.prevent="focusPreviousOption()"
-																									@keydown.arrow-down.prevent="focusNextOption()"
-																									role="listbox"
-																									:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																									tabindex="-1"
-																									class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																					>
-																							<template x-for="(key, index) in Object.keys(options)" :key="index">
-																									<li
-																													:id="name + 'Option' + focusedOptionIndex"
-																													@click="selectOption()"
-																													@mouseenter="focusedOptionIndex = index"
-																													@mouseleave="focusedOptionIndex = null"
-																													role="option"
-																													:aria-selected="focusedOptionIndex === index"
-																													:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																													class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																									>
-																													<span x-text="Object.values(options)[index]"
-																																:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																class="block font-normal truncate"
-																													></span>
-													
-																											<span
-																															x-show="key === value"
-																															:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																															class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																											>
-																															<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																	<path fill-rule="evenodd"
-																																				d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																				clip-rule="evenodd"/>
-																															</svg>
-																													</span>
-																									</li>
-																							</template>
-													
-																							<div
-																											x-show="! Object.keys(options).length"
-																											x-text="emptyOptionsMessage"
-																											class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																					</ul>
-																			</div>
-																	</div>
-													
-																	<script>
-																			function select(config) {
-																					return {
-																							data: config.data,
-													
-																							emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-													
-																							focusedOptionIndex: null,
-													
-																							name: config.name,
-													
-																							open: false,
-													
-																							options: {},
-													
-																							placeholder: config.placeholder ?? 'Select an option',
-													
-																							search: '',
-													
-																							value: config.value,
-													
-																							closeListbox: function () {
-																									this.open = false
-													
-																									this.focusedOptionIndex = null
-													
-																									this.search = ''
-																							},
-													
-																							focusNextOption: function () {
-																									if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-													
-																									if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-													
-																									this.focusedOptionIndex++
-													
-																									this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																											block: "center",
-																									})
-																							},
-													
-																							focusPreviousOption: function () {
-																									if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-													
-																									if (this.focusedOptionIndex <= 0) return
-													
-																									this.focusedOptionIndex--
-													
-																									this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																											block: "center",
-																									})
-																							},
-													
-																							init: function () {
-																									this.options = this.data
-													
-																									if (!(this.value in this.options)) this.value = null
-													
-																									this.$watch('search', ((value) => {
-																											if (!this.open || !value) return this.options = this.data
-													
-																											this.options = Object.keys(this.data)
-																													.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																													.reduce((options, key) => {
-																															options[key] = this.data[key]
-																															return options
-																													}, {})
-																									}))
-																							},
-													
-																							selectOption: function () {
-																									if (!this.open) return this.toggleListboxVisibility()
-													
-																									this.value = Object.keys(this.options)[this.focusedOptionIndex]
-													
-																									this.closeListbox()
-																							},
-													
-																							toggleListboxVisibility: function () {
-																									if (this.open) return this.closeListbox()
-													
-																									this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-													
-																									if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-													
-																									this.open = true
-													
-																									this.$nextTick(() => {
-																											this.$refs.search.focus()
-													
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center"
-																											})
-																									})
-																							},
-																					}
-																			}
-																	</script>
-															</div>
-													</div>
-										
-																
-														</div>
-												</form>
-										</div>
-								</div>
-						</div>
-				</div> <!-- fin card información personal-->
 
-				
 
-  </div>
-  
-						</div>
-						
+    </div>
 
-					</div>
+    <div class="bg-gray-100 w-full px-6 py-5">
+        <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+            <div class="md:grid md:grid-cols-3 md:gap-6">
+                <div class="md:col-span-3">
+                    <h3 class="text-lg font-medium leading-6 text-gray-900">Datos gineco - obstétricos </h3>
+                    <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
 
-					<div class="bg-gray-100 w-full px-6 py-5">
-						<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-								<div class="md:grid md:grid-cols-3 md:gap-6">
-										<div class="md:col-span-3">
-												<h3 class="text-lg font-medium leading-6 text-gray-900">Datos gineco - obstétricos 	</h3>
-												<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-										
-												<div class="mt-5 md:mt-5 md:col-span-3">
-														<form action="#" method="POST">
-																<div class="grid grid-cols-6 gap-6">
-																		
-																		<div class="col-span-6 sm:col-span-2">
-																		<label for="last-period" class="text-sm">Última menstruación </label>
-																		<input type="date" placeholder="DD/MM/YY" name="me" id="last-period" autocomplete="last-period" class="mt-1 p-2 h-11 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
-																		</div>
+                    <div class="mt-5 md:mt-5 md:col-span-3">
+                        <form action="#" method="POST">
+                            <div class="grid grid-cols-6 gap-6">
 
-																		</div>
-																		<br>
-																		<div class="col-span-6 sm:col-span-3">
-																				<div>
-																				<label id="listbox-label" class="text-sm">
-																						Anticonceptivos
-																				</label>
-																				<div class="max-w-xs mt-1">
-																						<div
-																										x-data="select({ data: { pil: 'Píldora', dh: 'DIU hormonal', dc: 'DIU cobre', in:'Inyecciones', par:'Parches', im:'Implante', ot:'Otro'}, emptyOptionsMessage: 'No se ha seleccionado ninguna opción.', name: 'Anticonceptivo', placeholder: 'Elige una opción' })"
-																										x-init="init()"
-																										@click.away="closeListbox()"
-																										@keydown.escape="closeListbox()"
-																										class="relative"
-																						>
-																										<span class="inline-block w-full rounded-md shadow-sm">
-																													<button type="button"
-																																	x-ref="button"
-																																	@click="toggleListboxVisibility()"
-																																	:aria-expanded="open"
-																																	aria-haspopup="listbox"
-																																	class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																													>
-																																<span
-																																				x-show="! open"
-																																				x-text="value in options ? options[value] : placeholder"
-																																				:class="{ 'text-gray-500': ! (value in options) }"
-																																				class="block truncate"
-																																></span>
-																		
-																																<input
-																																				x-ref="search"
-																																				x-show="open"
-																																				x-model="search"
-																																				@keydown.enter.stop.prevent="selectOption()"
-																																				@keydown.arrow-up.prevent="focusPreviousOption()"
-																																				@keydown.arrow-down.prevent="focusNextOption()"
-																																				type="search"
-																																				class="w-full h-full form-control focus:outline-none"
-																																/>
-																		
-																																<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																		<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																				<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																							stroke-linejoin="round"></path>
-																																		</svg>
-																																</span>
-																													</button>
-																										</span>
-																		
-																								<div
-																												x-show="open"
-																												x-transition:leave="transition ease-in duration-100"
-																												x-transition:leave-start="opacity-100"
-																												x-transition:leave-end="opacity-0"
-																												x-cloak
-																												class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																								>
-																										<ul
-																														x-ref="listbox"
-																														@keydown.enter.stop.prevent="selectOption()"
-																														@keydown.arrow-up.prevent="focusPreviousOption()"
-																														@keydown.arrow-down.prevent="focusNextOption()"
-																														role="listbox"
-																														:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																														tabindex="-1"
-																														class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																										>
-																												<template x-for="(key, index) in Object.keys(options)" :key="index">
-																														<li
-																																		:id="name + 'Option' + focusedOptionIndex"
-																																		@click="selectOption()"
-																																		@mouseenter="focusedOptionIndex = index"
-																																		@mouseleave="focusedOptionIndex = null"
-																																		role="option"
-																																		:aria-selected="focusedOptionIndex === index"
-																																		:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																		class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																														>
-																																		<span x-text="Object.values(options)[index]"
-																																					:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																					class="block font-normal truncate"
-																																		></span>
-																		
-																																<span
-																																				x-show="key === value"
-																																				:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																				class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																																>
-																																				<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																						<path fill-rule="evenodd"
-																																									d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																									clip-rule="evenodd"/>
-																																				</svg>
-																																		</span>
-																														</li>
-																												</template>
-																		
-																												<div
-																																x-show="! Object.keys(options).length"
-																																x-text="emptyOptionsMessage"
-																																class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																										</ul>
-																								</div>
-																						</div>
-																		
-																						<script>
-																								function select(config) {
-																										return {
-																												data: config.data,
-																		
-																												emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																		
-																												focusedOptionIndex: null,
-																		
-																												name: config.name,
-																		
-																												open: false,
-																		
-																												options: {},
-																		
-																												placeholder: config.placeholder ?? 'Select an option',
-																		
-																												search: '',
-																		
-																												value: config.value,
-																		
-																												closeListbox: function () {
-																														this.open = false
-																		
-																														this.focusedOptionIndex = null
-																		
-																														this.search = ''
-																												},
-																		
-																												focusNextOption: function () {
-																														if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																		
-																														if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																		
-																														this.focusedOptionIndex++
-																		
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center",
-																														})
-																												},
-																		
-																												focusPreviousOption: function () {
-																														if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																		
-																														if (this.focusedOptionIndex <= 0) return
-																		
-																														this.focusedOptionIndex--
-																		
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center",
-																														})
-																												},
-																		
-																												init: function () {
-																														this.options = this.data
-																		
-																														if (!(this.value in this.options)) this.value = null
-																		
-																														this.$watch('search', ((value) => {
-																																if (!this.open || !value) return this.options = this.data
-																		
-																																this.options = Object.keys(this.data)
-																																		.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																		.reduce((options, key) => {
-																																				options[key] = this.data[key]
-																																				return options
-																																		}, {})
-																														}))
-																												},
-																		
-																												selectOption: function () {
-																														if (!this.open) return this.toggleListboxVisibility()
-																		
-																														this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																		
-																														this.closeListbox()
-																												},
-																		
-																												toggleListboxVisibility: function () {
-																														if (this.open) return this.closeListbox()
-																		
-																														this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																		
-																														if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																		
-																														this.open = true
-																		
-																														this.$nextTick(() => {
-																																this.$refs.search.focus()
-																		
-																																this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																		block: "center"
-																																})
-																														})
-																												},
-																										}
-																								}
-																						</script>
-																				</div>
-																		</div>
-																		<br>
-																		<div class="col-span-6 sm:col-span-3">
-																			<div>
-																			<label id="listbox-label-pregnancy" class="text-sm">
-																					Embarazo
-																			</label>
-																			<div class="max-w-xs mt-1">
-																					<div
-																					x-data="select({ data: { si: 'Si', no: 'No'}, emptyOptionsMessage: 'No se ha seleccionado ninguna opción.', name: 'Lactancia', placeholder: 'Elige una opción' })"
-																									x-init="init()"
-																									@click.away="closeListbox()"
-																									@keydown.escape="closeListbox()"
-																									class="relative"
-																					>
-																									<span class="inline-block w-full rounded-md shadow-sm">
-																												<button type="button"
-																																x-ref="button"
-																																@click="toggleListboxVisibility()"
-																																:aria-expanded="open"
-																																aria-haspopup="listbox"
-																																class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																												>
-																															<span
-																																			x-show="! open"
-																																			x-text="value in options ? options[value] : placeholder"
-																																			:class="{ 'text-gray-500': ! (value in options) }"
-																																			class="block truncate"
-																															></span>
-																	
-																															<input
-																																			x-ref="search"
-																																			x-show="open"
-																																			x-model="search"
-																																			@keydown.enter.stop.prevent="selectOption()"
-																																			@keydown.arrow-up.prevent="focusPreviousOption()"
-																																			@keydown.arrow-down.prevent="focusNextOption()"
-																																			type="search"
-																																			class="w-full h-full form-control focus:outline-none"
-																															/>
-																	
-																															<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																	<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																			<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																						stroke-linejoin="round"></path>
-																																	</svg>
-																															</span>
-																												</button>
-																									</span>
-																	
-																							<div
-																											x-show="open"
-																											x-transition:leave="transition ease-in duration-100"
-																											x-transition:leave-start="opacity-100"
-																											x-transition:leave-end="opacity-0"
-																											x-cloak
-																											class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																							>
-																									<ul
-																													x-ref="listbox"
-																													@keydown.enter.stop.prevent="selectOption()"
-																													@keydown.arrow-up.prevent="focusPreviousOption()"
-																													@keydown.arrow-down.prevent="focusNextOption()"
-																													role="listbox"
-																													:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																													tabindex="-1"
-																													class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																									>
-																											<template x-for="(key, index) in Object.keys(options)" :key="index">
-																													<li
-																																	:id="name + 'Option' + focusedOptionIndex"
-																																	@click="selectOption()"
-																																	@mouseenter="focusedOptionIndex = index"
-																																	@mouseleave="focusedOptionIndex = null"
-																																	role="option"
-																																	:aria-selected="focusedOptionIndex === index"
-																																	:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																	class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																													>
-																																	<span x-text="Object.values(options)[index]"
-																																				:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																				class="block font-normal truncate"
-																																	></span>
-																	
-																															<span
-																																			x-show="key === value"
-																																			:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																			class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																															>
-																																			<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																					<path fill-rule="evenodd"
-																																								d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																								clip-rule="evenodd"/>
-																																			</svg>
-																																	</span>
-																													</li>
-																											</template>
-																	
-																											<div
-																															x-show="! Object.keys(options).length"
-																															x-text="emptyOptionsMessage"
-																															class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																									</ul>
-																							</div>
-																					</div>
-																	
-																					<script>
-																							function select(config) {
-																									return {
-																											data: config.data,
-																	
-																											emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																	
-																											focusedOptionIndex: null,
-																	
-																											name: config.name,
-																	
-																											open: false,
-																	
-																											options: {},
-																	
-																											placeholder: config.placeholder ?? 'Select an option',
-																	
-																											search: '',
-																	
-																											value: config.value,
-																	
-																											closeListbox: function () {
-																													this.open = false
-																	
-																													this.focusedOptionIndex = null
-																	
-																													this.search = ''
-																											},
-																	
-																											focusNextOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																	
-																													if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																	
-																													this.focusedOptionIndex++
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											focusPreviousOption: function () {
-																													if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																	
-																													if (this.focusedOptionIndex <= 0) return
-																	
-																													this.focusedOptionIndex--
-																	
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center",
-																													})
-																											},
-																	
-																											init: function () {
-																													this.options = this.data
-																	
-																													if (!(this.value in this.options)) this.value = null
-																	
-																													this.$watch('search', ((value) => {
-																															if (!this.open || !value) return this.options = this.data
-																	
-																															this.options = Object.keys(this.data)
-																																	.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																	.reduce((options, key) => {
-																																			options[key] = this.data[key]
-																																			return options
-																																	}, {})
-																													}))
-																											},
-																	
-																											selectOption: function () {
-																													if (!this.open) return this.toggleListboxVisibility()
-																	
-																													this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																	
-																													this.closeListbox()
-																											},
-																	
-																											toggleListboxVisibility: function () {
-																													if (this.open) return this.closeListbox()
-																	
-																													this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																	
-																													if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																	
-																													this.open = true
-																	
-																													this.$nextTick(() => {
-																															this.$refs.search.focus()
-																	
-																															this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																	block: "center"
-																															})
-																													})
-																											},
-																									}
-																							}
-																					</script>
-																			</div>
-																	</div>
-																	<br>
-																	<div class="col-span-6 sm:col-span-3">
-																		<div>
-																		<label id="listbox-label-breastfeeding" class="text-sm">
-																				Lactancia
-																		</label>
-																		<div class="max-w-xs mt-1">
-																				<div
-																				x-data="select({ data: { si: 'Si', no: 'No'}, emptyOptionsMessage: 'No se ha seleccionado ninguna opción.', name: 'Lactancia', placeholder: 'Elige una opción' })"
-																								x-init="init()"
-																								@click.away="closeListbox()"
-																								@keydown.escape="closeListbox()"
-																								class="relative"
-																				>
-																								<span class="inline-block w-full rounded-md shadow-sm">
-																											<button type="button"
-																															x-ref="button"
-																															@click="toggleListboxVisibility()"
-																															:aria-expanded="open"
-																															aria-haspopup="listbox"
-																															class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																											>
-																														<span
-																																		x-show="! open"
-																																		x-text="value in options ? options[value] : placeholder"
-																																		:class="{ 'text-gray-500': ! (value in options) }"
-																																		class="block truncate"
-																														></span>
-																
-																														<input
-																																		x-ref="search"
-																																		x-show="open"
-																																		x-model="search"
-																																		@keydown.enter.stop.prevent="selectOption()"
-																																		@keydown.arrow-up.prevent="focusPreviousOption()"
-																																		@keydown.arrow-down.prevent="focusNextOption()"
-																																		type="search"
-																																		class="w-full h-full form-control focus:outline-none"
-																														/>
-																
-																														<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																																<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																		<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																					stroke-linejoin="round"></path>
-																																</svg>
-																														</span>
-																											</button>
-																								</span>
-																
-																						<div
-																										x-show="open"
-																										x-transition:leave="transition ease-in duration-100"
-																										x-transition:leave-start="opacity-100"
-																										x-transition:leave-end="opacity-0"
-																										x-cloak
-																										class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																						>
-																								<ul
-																												x-ref="listbox"
-																												@keydown.enter.stop.prevent="selectOption()"
-																												@keydown.arrow-up.prevent="focusPreviousOption()"
-																												@keydown.arrow-down.prevent="focusNextOption()"
-																												role="listbox"
-																												:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																												tabindex="-1"
-																												class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																								>
-																										<template x-for="(key, index) in Object.keys(options)" :key="index">
-																												<li
-																																:id="name + 'Option' + focusedOptionIndex"
-																																@click="selectOption()"
-																																@mouseenter="focusedOptionIndex = index"
-																																@mouseleave="focusedOptionIndex = null"
-																																role="option"
-																																:aria-selected="focusedOptionIndex === index"
-																																:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																																class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																												>
-																																<span x-text="Object.values(options)[index]"
-																																			:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																			class="block font-normal truncate"
-																																></span>
-																
-																														<span
-																																		x-show="key === value"
-																																		:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																		class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																														>
-																																		<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																				<path fill-rule="evenodd"
-																																							d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																							clip-rule="evenodd"/>
-																																		</svg>
-																																</span>
-																												</li>
-																										</template>
-																
-																										<div
-																														x-show="! Object.keys(options).length"
-																														x-text="emptyOptionsMessage"
-																														class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																								</ul>
-																						</div>
-																				</div>
-																
-																				<script>
-																						function select(config) {
-																								return {
-																										data: config.data,
-																
-																										emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-																
-																										focusedOptionIndex: null,
-																
-																										name: config.name,
-																
-																										open: false,
-																
-																										options: {},
-																
-																										placeholder: config.placeholder ?? 'Select an option',
-																
-																										search: '',
-																
-																										value: config.value,
-																
-																										closeListbox: function () {
-																												this.open = false
-																
-																												this.focusedOptionIndex = null
-																
-																												this.search = ''
-																										},
-																
-																										focusNextOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-																
-																												if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-																
-																												this.focusedOptionIndex++
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										focusPreviousOption: function () {
-																												if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-																
-																												if (this.focusedOptionIndex <= 0) return
-																
-																												this.focusedOptionIndex--
-																
-																												this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																														block: "center",
-																												})
-																										},
-																
-																										init: function () {
-																												this.options = this.data
-																
-																												if (!(this.value in this.options)) this.value = null
-																
-																												this.$watch('search', ((value) => {
-																														if (!this.open || !value) return this.options = this.data
-																
-																														this.options = Object.keys(this.data)
-																																.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																																.reduce((options, key) => {
-																																		options[key] = this.data[key]
-																																		return options
-																																}, {})
-																												}))
-																										},
-																
-																										selectOption: function () {
-																												if (!this.open) return this.toggleListboxVisibility()
-																
-																												this.value = Object.keys(this.options)[this.focusedOptionIndex]
-																
-																												this.closeListbox()
-																										},
-																
-																										toggleListboxVisibility: function () {
-																												if (this.open) return this.closeListbox()
-																
-																												this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-																
-																												if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-																
-																												this.open = true
-																
-																												this.$nextTick(() => {
-																														this.$refs.search.focus()
-																
-																														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																																block: "center"
-																														})
-																												})
-																										},
-																								}
-																						}
-																				</script>
-																		</div>
-																</div>
-																		
-																</div>
-														</form>
-												</div>
-										</div>
-								</div>
-						</div> <!-- fin card información personal-->
-					</div>
-				</div>
-				</div>
-				<div class="bg-gray-100 w-full px-6 py-5">
-					<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-							<!-- This example requires Tailwind CSS v2.0+ -->
-  
-								<div class="md:col-span-3">
-										<h3 class="text-lg font-medium leading-6 text-gray-900">Laboratorios</h3>
-      					</div>
-									<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-										<dl class="sm:divide-y sm:divide-gray-200">
-											<div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-												<dt class="text-sm medium">
-													Quìmica Sanguinea
-												</dt>
-												<dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-													<button type="button" class="relative block w-full border-2 border-gray-300 border-dashed rounded-lg p-1 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-														<svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-															<path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-														</svg>
-														<span class="mt-2 block text-sm font-medium text-gray-900">
-															Agregar estudio
-														</span>
-													</button>
-												</dd>
-											</div>
-											<div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-												<dt class="text-sm medium">
-													Biometría hemática
-												</dt>	
-												
-												<dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-													<div class="flex justify-between">
-                              <label for="allergies" class="block text-sm font-medium text-white">Agregar</label> 
-                              <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                        <!-- Heroicon name: outline/plus -->
-                              <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                              </svg>
-                               Agregar
-                             </button>
+                                <div class="col-span-6 sm:col-span-2">
+                                    <label for="last-period" class="text-sm">Última menstruación </label>
+                                    <input type="date" placeholder="DD/MM/YY" name="me" id="last-period"
+                                        autocomplete="last-period"
+                                        class="mt-1 p-2 h-11 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md">
+                                </div>
+
                             </div>
-													<ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
-													
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-														
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	resume_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400 hover:text-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400 hover:text-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	coverletter_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-													</ul>
-												</dd>
-											</div>
-											<div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-												<dt class="text-sm medium">
-													Examen general de orina
-												</dt>
-												<dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-													<div class="flex justify-between">
-                              <label for="allergies" class="block text-sm font-medium text-white">Agregar</label> 
-                              <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                        <!-- Heroicon name: outline/plus -->
-                              <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                              </svg>
-                               Agregar
-                             </button>
-                            </div>
-													<ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
-													
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-														
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	resume_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	coverletter_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-													</ul>
-												</dd>
-											</div>
-											<div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-												<dt class="text-sm medium">
-													Perfil lipídico
-												</dt>
-												<dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-													<div class="flex justify-between">
-                              <label for="allergies" class="block text-sm font-medium text-white">Agregar</label> 
-                              <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                        <!-- Heroicon name: outline/plus -->
-                              <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                              </svg>
-                               Agregar
-                             </button>
-                            </div>
-													<ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
-													
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-														
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	resume_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	coverletter_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-													</ul>
-												</dd>
-											</div>
-											<div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-												<dt class="text-sm medium">
-													Perfil tiroideo
-												</dt>
-												<dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
-													<div class="flex justify-between">
-                              <label for="allergies" class="block text-sm font-medium text-white">Agregar</label> 
-                              <button type="button" class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                                        <!-- Heroicon name: outline/plus -->
-                              <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
-                              </svg>
-                               Agregar
-                             </button>
-                            </div>
-													<ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
-													
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-														
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	resume_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-														<li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
-															<div class="w-0 flex-1 flex items-center">
-																<!-- Heroicon name: solid/paper-clip -->
-																<svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-																	<path fill-rule="evenodd" d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z" clip-rule="evenodd" />
-																</svg>
-																<span class="ml-2 flex-1 w-0 truncate">
-																	coverletter_back_end_developer.pdf
-																</span>
-															</div>
-															<div class="ml-4 flex-shrink-0">
-															<span class="ml-4 flex-shrink-0 flex items-start space-x-4">
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-																	</svg>
-																</button>
-																<span class="text-gray-300" aria-hidden="true">|</span>
-																<button type="button" class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
-																	<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-																		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-																	</svg>
-																</button>
-															</span>
-															</div>
-														</li>
-													</ul>
-												</dd>
-											</div>
-										</dl>
-									</div>
-							</div>
-					</div> <!-- fin card información personal-->
+                            <br>
+                            <div class="col-span-6 sm:col-span-3">
+                                <div>
+                                <!--Select-->
+                                        <div class="col-span-6 sm:col-span-6 mt-8">
+                                            <div>
+                                                <label for="anticonceptivos" class="block text-sm ">Anticonceptivos</label>
+                                                <select id="anticonceptivos" name="anticonceptivos" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                    <option disabled selected>Elige una opción</option>
+                                                    <option>Píldora</option>
+                                                    <option>DIU hormonal</option>
+                                                    <option>DIU cobre</option>
+                                                    <option>Inyecciones</option>
+                                                    <option>Parches</option>
+                                                    <option>Implante</option>
+                                                    <option>Otro</option>
+                                                </select>
+                                            </div>
+                                         </div>
+                                <!--Fin Select-->
+                                </div>
+                                <br>
+                                <div class="col-span-6 sm:col-span-3">
+                                   <!--Select-->
+                                        <div class="col-span-6 sm:col-span-6 mt-8">
+                                            <div>
+                                                <label for="embarazo" class="block text-sm ">Embarazo</label>
+                                                <select id="embarazo" name="embarazo" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                    <option disabled selected>Elige una opción</option>
+                                                    <option>Si</option>
+                                                    <option>No</option>
+                                                </select>
+                                            </div>
+                                         </div>
+                                <!--Fin Select-->
+                                    <br>
+                                    <!--Select-->
+                                        <div class="col-span-6 sm:col-span-6 mt-8">
+                                            <div>
+                                                <label for="lactancia" class="block text-sm ">Lactancia</label>
+                                                <select id="lactancia" name="lactancia" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                    <option disabled selected>Elige una opción</option>
+                                                    <option>Si</option>
+                                                    <option>No</option>
+                                                </select>
+                                            </div>
+                                         </div>
+                                <!--Fin Select-->
 
-				
+                                    </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div> <!-- fin card información personal-->
+    </div>
+    </div>
+    </div>
+    <div class="bg-gray-100 w-full px-6 py-5">
+        <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+            <!-- This example requires Tailwind CSS v2.0+ -->
+
+            <div class="md:col-span-3">
+                <h3 class="text-lg font-medium leading-6 text-gray-900">Laboratorios</h3>
+            </div>
+            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+            <dl class="sm:divide-y sm:divide-gray-200">
+                <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                    <dt class="text-sm medium">
+                        Quìmica Sanguinea
+                    </dt>
+                    <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                        <button type="button"
+                            class="relative block w-full border-2 border-gray-300 border-dashed rounded-lg p-1 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24"
+                                stroke="currentColor" aria-hidden="true">
+                                <path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M9 13h6m-3-3v6m-9 1V7a2 2 0 012-2h6l2 2h6a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+                            </svg>
+                            <span class="mt-2 block text-sm font-medium text-gray-900">
+                                Agregar estudio
+                            </span>
+                        </button>
+                    </dd>
+                </div>
+                <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                    <dt class="text-sm medium">
+                        Biometría hemática
+                    </dt>
+
+                    <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                        <div class="flex justify-between">
+                            <label for="allergies" class="block text-sm font-medium text-white">Agregar</label>
+                            <button type="button"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                <!-- Heroicon name: outline/plus -->
+                                <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                    viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                </svg>
+                                Agregar
+                            </button>
+                        </div>
+                        <ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
+
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        resume_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400 hover:text-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400 hover:text-gray-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        coverletter_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+                <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                    <dt class="text-sm medium">
+                        Examen general de orina
+                    </dt>
+                    <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                        <div class="flex justify-between">
+                            <label for="allergies" class="block text-sm font-medium text-white">Agregar</label>
+                            <button type="button"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                <!-- Heroicon name: outline/plus -->
+                                <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                    viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                </svg>
+                                Agregar
+                            </button>
+                        </div>
+                        <ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
+
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        resume_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        coverletter_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+                <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                    <dt class="text-sm medium">
+                        Perfil lipídico
+                    </dt>
+                    <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                        <div class="flex justify-between">
+                            <label for="allergies" class="block text-sm font-medium text-white">Agregar</label>
+                            <button type="button"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                <!-- Heroicon name: outline/plus -->
+                                <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                    viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                </svg>
+                                Agregar
+                            </button>
+                        </div>
+                        <ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
+
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        resume_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        coverletter_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+                <div class="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+                    <dt class="text-sm medium">
+                        Perfil tiroideo
+                    </dt>
+                    <dd class="mt-1 text-sm text-gray-900 sm:mt-0 sm:col-span-2">
+                        <div class="flex justify-between">
+                            <label for="allergies" class="block text-sm font-medium text-white">Agregar</label>
+                            <button type="button"
+                                class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                <!-- Heroicon name: outline/plus -->
+                                <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5" fill="none"
+                                    viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                </svg>
+                                Agregar
+                            </button>
+                        </div>
+                        <ul role="list" class="border border-gray-200 rounded-md divide-y divide-gray-200">
+
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        resume_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                            <li class="pl-3 pr-4 py-3 flex items-center justify-between text-sm">
+                                <div class="w-0 flex-1 flex items-center">
+                                    <!-- Heroicon name: solid/paper-clip -->
+                                    <svg class="flex-shrink-0 h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg"
+                                        viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                        <path fill-rule="evenodd"
+                                            d="M8 4a3 3 0 00-3 3v4a5 5 0 0010 0V7a1 1 0 112 0v4a7 7 0 11-14 0V7a5 5 0 0110 0v4a3 3 0 11-6 0V7a1 1 0 012 0v4a1 1 0 102 0V7a3 3 0 00-3-3z"
+                                            clip-rule="evenodd" />
+                                    </svg>
+                                    <span class="ml-2 flex-1 w-0 truncate">
+                                        coverletter_back_end_developer.pdf
+                                    </span>
+                                </div>
+                                <div class="ml-4 flex-shrink-0">
+                                    <span class="ml-4 flex-shrink-0 flex items-start space-x-4">
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                            </svg>
+                                        </button>
+                                        <span class="text-gray-300" aria-hidden="true">|</span>
+                                        <button type="button"
+                                            class="bg-white rounded-md font-medium text-gray-400  hover:text-gray-400  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 ">
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                                viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                                            </svg>
+                                        </button>
+                                    </span>
+                                </div>
+                            </li>
+                        </ul>
+                    </dd>
+                </div>
+            </dl>
+        </div>
+    </div>
+    </div> <!-- fin card información personal-->
+</turbo-frame>

--- a/app/views/patients/notes/new.html.erb
+++ b/app/views/patients/notes/new.html.erb
@@ -1,128 +1,217 @@
-<div class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog" aria-modal="true">
-    <div class="absolute inset-0 overflow-hidden">
-      <!--
-        Background overlay, show/hide based on slide-over state.
-  
-        Entering: "ease-in-out duration-500"
-          From: "opacity-0"
-          To: "opacity-100"
-        Leaving: "ease-in-out duration-500"
-          From: "opacity-100"
-          To: "opacity-0"
-      -->
-      <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-      <div class="fixed inset-y-0 right-0 pl-10 max-w-full flex">
-        <!--
-          Slide-over panel, show/hide based on slide-over state.
-  
-          Entering: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-full"
-            To: "translate-x-0"
-          Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-0"
-            To: "translate-x-full"
-        -->
-        <div class="relative w-screen max-w-3xl">
-          <!--
-            Close button, show/hide based on slide-over state.
-  
-            Entering: "ease-in-out duration-500"
-              From: "opacity-0"
-              To: "opacity-100"
-            Leaving: "ease-in-out duration-500"
-              From: "opacity-100"
-              To: "opacity-0"
-          -->
-          <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
-            <button type="button" class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
-              <span class="sr-only">Close panel</span>
-              <!-- Heroicon name: outline/x -->
-              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-  
-          <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
-            <div class="px-4 sm:px-6 mt-4">
-                <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
-                    Expediente
-                </h2>
-                <div class="mt-5">
-                    <div class="sm:hidden">
-                    <label for="tabs" class="sr-only">Select a tab</label>
-                    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-                    <select id="tabs" name="tabs" class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md">
-                        <option>Generales</option>
-                
-                        <option>Historial</option>
-                
-                        <option>Antropométrico</option>
-                
-                        <option>Hábitos</option>
-                
-                        <option>Actividad física</option>
+<turbo-frame turbo-frame data-controller="operation-tabs-shower" data-operation-tabs-shower-target="turboFrame"
+    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame" id="notes">
+    <div class="border-t border-gray-200">
+        <div class="mt-2 relative flex-1 overflow-y-auto">
+            <!-- Replace with your content -->
+            <div class="bg-gray-100 w-full px-6 py-5">
 
-                        <option selected>Notas</option>
-                    </select>
-                    </div>
-                    <div class="hidden sm:block">
-                    <nav class="flex space-x-4" aria-label="Tabs">
-                        <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
-                        <a href="general" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Generales
-                        </a>
-
-                        <a href="history" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Historial
-                        </a>
-
-												<a href="anthropometric" class=" text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Antropométrico
-                        </a>
-                                        
-                        <a href="habits" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Hábitos
-                        </a>
-
-                        <a href="physical_activity" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md" >
-                        Actividad física
-                        </a>
-                
-                        <a href="notes" class="bg-indigo-100 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md" aria-current="page">
-                        Notas
-                        </a>
-                    </nav>
-                    </div>
-                </div>
-  
-            </div>
-						
-            <div class="mt-2 relative flex-1 overflow-y-auto">
-              <!-- Replace with your content --> 
-						
-            	<div class="bg-gray-100 w-full px-6 py-5">
-               
-                <div class="bg-white shadow px-4 py-5 mt-6 sm:rounded-lg sm:p-6">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <!-- Inicia card Tipo de alimentación -->
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
                             <h3>Notas </h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
                             <div class="mt-3 md:mt-3 md:col-span-3">
-                                
-																<div class="col-span-6 sm:col-span-4 mt-8">
-																	<label for="notes" class="block text-sm font-medium text-gray-500">Notas del paciente</label>
-																	<textarea name="notes" autocomplete="notes" class="mt-1 px-4 py-60 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md"></textarea>	
-																</div>
-																	
 
-																
-																</div>
-													</div>
+
+                                <div class="col-span-6 sm:col-span-4 mt-2">
+                                    <label for="notes"
+                                        class="mt-1 inline-flex rounded-full items-center ml-1 py-0.5 pl-2.5 pr-1 text-sm">Sólo
+                                        tu puedes ver estas notas </label>
+                                    <span class="text-gray-500 ml-auto inline-block px-2 text-sm rounded-full">
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+                                            viewBox="0 0 24 24" stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                    </span>
+
+                                    <div class="flex justify-between">
+                                        <label for="allergies" class="block text-sm font-medium text-white">Agregar
+                                            nota</label>
+                                        <button type="button"
+                                            class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-full text-indigo-600 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                            <!-- Heroicon name: outline/plus -->
+                                            <svg xmlns="http://www.w3.org/2000/svg" class="-ml-0.5 mr-1 h-5 w-5"
+                                                fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                    d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                                            </svg>
+                                            Agregar nota
+                                        </button>
+                                    </div>
+
+
+
+                                    <div class="bg-gray-50 shadow px-4 py-5 mt-4 sm:rounded-lg sm:p-6 ">
+
+                                        <!-- This example requires Tailwind CSS v2.0+ -->
+                                        <ul role="list"
+                                            class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        Lorem Ipsum is simply dummy text of the printing and
+                                                        typesetting industry. Lorem Ipsum has been the
+                                                        industry's standard dummy text ever since the 1500s,
+                                                        when an unknown printer took a galley of type and
+                                                        scrambled it to make a type specimen book.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">5 Oct
+                                                                2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4 ml-2">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        Contrary to popular belief, Lorem Ipsum is not
+                                                        simply random text. It has roots in a piece of
+                                                        classical Latin literature from 45 BC, making it
+                                                        over 2000 years old. Richard McClintock, a Latin
+                                                        professor at Hampden-Sydney College in Virginia.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">12
+                                                                Oct 2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        It has survived not only five centuries, but also
+                                                        the leap into electronic typesetting, remaining
+                                                        essentially unchanged. It was popularised in the
+                                                        1960s with the release of Letraset sheets containing
+                                                        Lorem Ipsum passages, and more recently with
+                                                        desktop.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">20
+                                                                Oct 2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+                                            <li
+                                                class="col-span-2 flex flex-col text-left bg-white rounded-lg shadow divide-y divide-gray-200 mt-4 ml-2">
+                                                <div class="flex-1 flex flex-col p-8">
+                                                    <label for="notes" class="text-sm">
+                                                        Lorem Ipsum is simply dummy text of the printing and
+                                                        typesetting industry. Lorem Ipsum has been the
+                                                        industry's standard dummy text ever since the 1500s,
+                                                        when an unknown printer took a galley of type and
+                                                        scrambled it to make a type specimen book.
+                                                    </label>
+
+                                                </div>
+                                                <div>
+                                                    <div class="flex justify-between">
+                                                        <div class="flex-1 flex p-3">
+
+                                                            <label class="text-sm  mt-3 text-gray-400">3 Nov
+                                                                2020</label>
+                                                        </div>
+                                                        <div class="p-3">
+                                                            <button
+                                                                class="inline-flex text-right items-center border border-gray-50 text-sm leading-4 font-medium rounded-full text-gray-100 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-100">
+
+                                                                <svg xmlns="http://www.w3.org/2000/svg"
+                                                                    class="h-6 w-6 text-gray-400 " fill="none"
+                                                                    viewBox="0 0 24 24" stroke="currentColor">
+                                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                                        stroke-width="2"
+                                                                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </li>
+
+
+                                            <!-- More people... -->
+                                        </ul>
+
+
+
+                                    </div>
+
+                                </div>
+
+
+
+                            </div>
                         </div>
                     </div>
-                </div> <!-- fin card Motivo de consulta-->
-								
-            </div>
-							
-						
+                </div>
+            </div> <!-- fin card Motivo de consulta-->
+
+        </div>
+    </div>
+</turbo-frame>

--- a/app/views/patients/physical_activities/new.html.erb
+++ b/app/views/patients/physical_activities/new.html.erb
@@ -1,861 +1,194 @@
-<div class="fixed inset-0 overflow-hidden" aria-labelledby="slide-over-title" role="dialog" aria-modal="true">
-    <div class="absolute inset-0 overflow-hidden">
-      <!--
-        Background overlay, show/hide based on slide-over state.
-  
-        Entering: "ease-in-out duration-500"
-          From: "opacity-0"
-          To: "opacity-100"
-        Leaving: "ease-in-out duration-500"
-          From: "opacity-100"
-          To: "opacity-0"
-      -->
-      <div class="absolute inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
-      <div class="fixed inset-y-0 right-0 pl-10 max-w-full flex">
-        <!--
-          Slide-over panel, show/hide based on slide-over state.
-  
-          Entering: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-full"
-            To: "translate-x-0"
-          Leaving: "transform transition ease-in-out duration-500 sm:duration-700"
-            From: "translate-x-0"
-            To: "translate-x-full"
-        -->
-        <div class="relative w-screen max-w-3xl">
-          <!--
-            Close button, show/hide based on slide-over state.
-  
-            Entering: "ease-in-out duration-500"
-              From: "opacity-0"
-              To: "opacity-100"
-            Leaving: "ease-in-out duration-500"
-              From: "opacity-100"
-              To: "opacity-0"
-          -->
-          <div class="absolute top-0 left-0 -ml-8 pt-4 pr-2 flex sm:-ml-10 sm:pr-4">
-            <button type="button" class="rounded-md text-gray-300 hover:text-white focus:outline-none focus:ring-2 focus:ring-white">
-              <span class="sr-only">Close panel</span>
-              <!-- Heroicon name: outline/x -->
-              <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-  
-          <div class="h-full flex flex-col bg-white shadow-xl overflow-y-scroll">
-            <div class="px-4 sm:px-6 mt-4">
-                <h2 class="text-xl font-semibold text-gray-900" id="slide-over-title">
-                    Expediente
-                </h2>
-                <div class="mt-5">
-                    <div class="sm:hidden">
-                    <label for="tabs" class="sr-only">Select a tab</label>
-                    <!-- Use an "onChange" listener to redirect the user to the selected tab URL. -->
-                    <select id="tabs" name="tabs" class="block w-full focus:ring-indigo-500 focus:border-indigo-500 border-gray-300 rounded-md">
-                        <option>Generales</option>
-                
-                        <option >Historial</option>
-
-												<option >Antropométrico</option>
-                
-                        <option >Hábitos</option>
-                
-                        <option selected>Actividad física</option>
-
-                        <option>Notas</option>
-                    </select>
-                    </div>
-                    <div class="hidden sm:block">
-                    <nav class="flex space-x-4" aria-label="Tabs">
-                        <!-- Current: "bg-indigo-100 text-indigo-700", Default: "text-gray-500 hover:text-gray-700" -->
-                        <a href="general" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Generales
-                        </a>
-
-                        <a href="history" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Historial
-                        </a>
-
-												<a href="anthropometric" class=" text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Antropométrico
-                        </a>
-                
-                        <a href="habits" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Hábitos
-                        </a>
-
-                        <a href="physical_activity" class= "bg-indigo-100 text-indigo-700 px-3 py-2 font-medium text-sm rounded-md" aria-current="page">
-                        Actividad física
-                        </a>
-                
-                        <a href="notes" class="text-gray-500 hover:text-gray-700 px-3 py-2 font-medium text-sm rounded-md">
-                        Notas
-                        </a>
-                    </nav>
-                    </div>
-                </div>
-  
-            </div>
-						
-             <div class="mt-2 relative flex-1 overflow-y-auto">
-              <!-- Replace with your content --> 
+<turbo-frame turbo-frame data-controller="operation-tabs-shower" data-operation-tabs-shower-target="turboFrame"
+    data-action="refreshOperationTurboFrame@window->operation-tabs-shower#updateTurboFrame" id="physical_activity">
+    <div class="border-t border-gray-200">
+        <div class="mt-2 relative flex-1 overflow-y-auto">
+            <!-- Replace with your content -->
             <div class="bg-gray-100 w-full px-6 py-5">
                 <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
                     <div class="md:grid md:grid-cols-3 md:gap-6">
                         <div class="md:col-span-3">
                             <h3>Tipo de ejercicio</h3>
                             <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-                        
+
                             <div class="mt-3 md:mt-3 md:col-span-3">
                                 <fieldset>
                                     <legend class="text-base font-medium text-gray-900"></legend>
-																		<!--<div class="text-md">
-																			<h5 class="text-lg font-medium leading-6 text-gray-900">Tipo de ejercicio</h5>
-																			</div>-->
-                                      <div class="grid grid-cols-4">
-                                        
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="ninguna" name="ninguno" class="checkbox"/>
-																						Ninguno
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="walk" name="walk" class="checkbox"/>
-																						Caminata
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="run" name="run" class="checkbox"/>
-																						Correr
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="weights" name="weights" class="checkbox"/>
-																						Pesas 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label  class="medium">
-																						<input type="checkbox" id="functional" name="functional" class="checkbox"/>
-																						Funcional 
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="bike" name="bike" class="checkbox"/>
-																						Bicicleta
-																					</label>
-																				</div>
-																				<div class="mt-4">
-																					<label class="medium">
-																						<input type="checkbox" id="swimming" name="swimming" class="checkbox"/>
-																						Natación
-																					</label>
-																				</div>
-																			
-                                      </div>	
-																			
+                                    <!--<div class="text-md">
+                                                                              <h5 class="text-lg font-medium leading-6 text-gray-900">Tipo de ejercicio</h5>
+                                                                              </div>-->
+                                    <div class="grid grid-cols-4">
+
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="ninguna" name="ninguno" class="checkbox" />
+                                                Ninguno
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="walk" name="walk" class="checkbox" />
+                                                Caminata
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="run" name="run" class="checkbox" />
+                                                Correr
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="weights" name="weights" class="checkbox" />
+                                                Pesas
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="functional" name="functional"
+                                                    class="checkbox" />
+                                                Funcional
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="bike" name="bike" class="checkbox" />
+                                                Bicicleta
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="swimming" name="swimming" class="checkbox" />
+                                                Natación
+                                            </label>
+                                        </div>
+
+                                    </div>
+
                                 </fieldset>
                                 <div class="col-span-6 sm:col-span-4 mt-8">
                                     <label for="motive" class="text-sm">Otro tipo de ejercicio</label>
-                                    <input type="text" name="motive" id="motive" autocomplete="motive" class="placeholder">
+                                    <input type="text" name="motive" id="motive" autocomplete="motive"
+                                        class="placeholder">
                                 </div>
-																<div class="col-span-6 sm:col-span-4 mt-8">
-																	<label for="desc_activity" class="text-sm">Descripción de la actividad </label>
-																	<textarea name="desc_activity" autocomplete="desc_activity" class="mt-1 px-4 py-14 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md"></textarea>	
-																</div>
-																	<div class="grid grid-cols-6 gap-6">
-																		
-																<!--Select-->
-																	
-																<div class="col-span-6 sm:col-span-6 mt-8">
-																	<div>
-																	<label id="listbox-label-act-fisica" class="text-sm">
-																			Nivel de actividad física
-																	</label>
-																	<div class="max-w-screen-2xl mt-1">
-																			<div
-																							x-data="select({ data: { inactivo: 'Inactivo (No realiza actividad física)', principiante: 'Principiante (1 a 6 meses realizando actividad física)', intermedio: 'Intermedio (Más de 6 meses realizando actividad física)', avanzado: 'Avanzado (Más de 1 año realizando actividad física)'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'Elige una opción' })"
-																							x-init="init()"
-																							@click.away="closeListbox()"
-																							@keydown.escape="closeListbox()"
-																							class="relative"
-																			>
-																							<span class="inline-block w-full rounded-md shadow-sm">
-																										<button type="button"
-																														x-ref="button"
-																														@click="toggleListboxVisibility()"
-																														:aria-expanded="open"
-																														aria-haspopup="listbox"
-																														class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																										>
-																													<span
-																																	x-show="! open"
-																																	x-text="value in options ? options[value] : placeholder"
-																																	:class="{ 'text-gray-500': ! (value in options) }"
-																																	class="block truncate"
-																													></span>
-															
-																													<input
-																																	x-ref="search"
-																																	x-show="open"
-																																	x-model="search"
-																																	@keydown.enter.stop.prevent="selectOption()"
-																																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																																	@keydown.arrow-down.prevent="focusNextOption()"
-																																	type="search"
-																																	class="w-full h-full form-control focus:outline-none"
-																													/>
-															
-																													<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																															<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																																	<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																																				stroke-linejoin="round"></path>
-																															</svg>
-																													</span>
-																										</button>
-																							</span>
-															
-																					<div
-																									x-show="open"
-																									x-transition:leave="transition ease-in duration-100"
-																									x-transition:leave-start="opacity-100"
-																									x-transition:leave-end="opacity-0"
-																									x-cloak
-																									class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-																					>
-																							<ul
-																											x-ref="listbox"
-																											@keydown.enter.stop.prevent="selectOption()"
-																											@keydown.arrow-up.prevent="focusPreviousOption()"
-																											@keydown.arrow-down.prevent="focusNextOption()"
-																											role="listbox"
-																											:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																											tabindex="-1"
-																											class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-																							>
-																									<template x-for="(key, index) in Object.keys(options)" :key="index">
-																											<li
-																															:id="name + 'Option' + focusedOptionIndex"
-																															@click="selectOption()"
-																															@mouseenter="focusedOptionIndex = index"
-																															@mouseleave="focusedOptionIndex = null"
-																															role="option"
-																															:aria-selected="focusedOptionIndex === index"
-																															:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																															class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																											>
-																															<span x-text="Object.values(options)[index]"
-																																		:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																																		class="block font-normal truncate"
-																															></span>
-															
-																													<span
-																																	x-show="key === value"
-																																	:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																																	class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																													>
-																																	<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																																			<path fill-rule="evenodd"
-																																						d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																																						clip-rule="evenodd"/>
-																																	</svg>
-																															</span>
-																											</li>
-																									</template>
-															
-																									<div
-																													x-show="! Object.keys(options).length"
-																													x-text="emptyOptionsMessage"
-																													class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-																							</ul>
-																					</div>
-																			</div>
-															
-																			<script>
-																					function select(config) {
-																							return {
-																									data: config.data,
-															
-																									emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-															
-																									focusedOptionIndex: null,
-															
-																									name: config.name,
-															
-																									open: false,
-															
-																									options: {},
-															
-																									placeholder: config.placeholder ?? 'Select an option',
-															
-																									search: '',
-															
-																									value: config.value,
-															
-																									closeListbox: function () {
-																											this.open = false
-															
-																											this.focusedOptionIndex = null
-															
-																											this.search = ''
-																									},
-															
-																									focusNextOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-															
-																											if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-															
-																											this.focusedOptionIndex++
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									focusPreviousOption: function () {
-																											if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-															
-																											if (this.focusedOptionIndex <= 0) return
-															
-																											this.focusedOptionIndex--
-															
-																											this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																													block: "center",
-																											})
-																									},
-															
-																									init: function () {
-																											this.options = this.data
-															
-																											if (!(this.value in this.options)) this.value = null
-															
-																											this.$watch('search', ((value) => {
-																													if (!this.open || !value) return this.options = this.data
-															
-																													this.options = Object.keys(this.data)
-																															.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																															.reduce((options, key) => {
-																																	options[key] = this.data[key]
-																																	return options
-																															}, {})
-																											}))
-																									},
-															
-																									selectOption: function () {
-																											if (!this.open) return this.toggleListboxVisibility()
-															
-																											this.value = Object.keys(this.options)[this.focusedOptionIndex]
-															
-																											this.closeListbox()
-																									},
-															
-																									toggleListboxVisibility: function () {
-																											if (this.open) return this.closeListbox()
-															
-																											this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-															
-																											if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-															
-																											this.open = true
-															
-																											this.$nextTick(() => {
-																													this.$refs.search.focus()
-															
-																													this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																															block: "center"
-																													})
-																											})
-																									},
-																							}
-																					}
-																			</script>
-																	</div>
-															</div>
-																<!--Fin select-->
-																<div class="grid grid-cols-6 gap-6">
-																	<div class="col-span-6 sm:col-span-3 mt-4">
-																		<label for="hora" class="text-sm">Hora en la que se ejercita</label>
-																		<input type="time" name="hora" id="hora" autocomplete="family-name" class="placeholder">
-																	</div>
-																</div>
+                                <div class="col-span-6 sm:col-span-4 mt-8">
+                                    <label for="desc_activity" class="text-sm">Descripción de la actividad </label>
+                                    <textarea name="desc_activity" autocomplete="desc_activity"
+                                        class="mt-1 px-4 py-14 p-2 border focus:ring-indigo-500 focus:border-indigo-500 block w-full sm:text-md border-gray-300 rounded-md"></textarea>
+                                </div>
+                                <div class="grid grid-cols-6 gap-6">
 
-																
-																</div>
-													</div>
+                                    <!--Select-->
+                                            <div class="col-span-6 sm:col-span-3 mt-8">
+                                                <div>
+                                                    <label for="act-fisica" class="block text-sm font-medium text-gray-700"> Nivel de actividad física </label>
+                                                    <select id="act-fisica" name="act-fisica" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Inactivo (No realiza actividad física)</option>
+                                                        <option>Principiante (1 a 6 mese realizando actividad física)</option>
+                                                        <option>Intermedio (Más de 6 meses realizando actividad física)</option>
+                                                        <option>Avanzado (Más de 1 año realizando actividad física)</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                            <!--Fin Select-->
+                                            <div class="col-span-6 sm:col-span-3 mt-4">
+                                                <label for="hora" class="text-sm">Hora en la que se ejercita</label>
+                                                <input type="time" name="hora" id="hora" autocomplete="family-name"
+                                                    class="placeholder">
+                                            </div>
+                                        </div>
+
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div> <!-- fin card Motivo de consulta-->
+
+                </div>
+
+
+                <!-- /End replace -->
+            </div>
+
+            <div class="bg-gray-100 w-full px-6 py-5">
+                <div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
+                    <div class="md:grid md:grid-cols-3 md:gap-6">
+                        <div class="md:col-span-3">
+                            <h3 class="text-lg font-medium leading-6 text-gray-900">Intensidad </h3>
+                            <div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
+                            <legend class="text-base font-medium text-gray-900"></legend>
+
+                            <div class="mt-4 space-y-4 ">
+                                <div class="flex items-start">
+
+                                    <div class="grid grid-cols-1">
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="leve" name="leve" class="checkbox" />
+                                                Leve
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="moderate" name="moderate" class="checkbox" />
+                                                Moderada
+                                            </label>
+                                        </div>
+                                        <div class="mt-4">
+                                            <label class="medium">
+                                                <input type="checkbox" id="intense" name="intense" class="checkbox" />
+                                                Intensa
+                                            </label>
+                                        </div>
+
+                                    </div>
+
+                                </div>
+
+                                </fieldset>
+                                <!--Select-->
+                                            <div class="col-span-6 sm:col-span-6 mt-8">
+                                                <div>
+                                                    <label for="frequency " class="block text-sm font-medium text-gray-700">Frecuencia (días a la semana)</label>
+                                                    <select id="frequency " name="frequency " class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>1</option>
+                                                        <option>2</option>
+                                                        <option>3</option>
+                                                        <option>4</option>
+                                                        <option>5</option>
+                                                        <option>6</option>
+                                                        <option>7</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                            <!--Fin Select-->
+
+
+                                    <!--Select-->
+                                            <div class="col-span-6 sm:col-span-6 mt-8">
+                                                <div>
+                                                    <label for="duration" class="block text-sm font-medium text-gray-700">Duración</label>
+                                                    <select id="duration" name="duration" class="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm rounded-md">
+                                                        <option disabled selected>Elige una opción</option>
+                                                        <option>Menos de 30 minutos</option>
+                                                        <option>30 minutos a 1 hora</option>
+                                                        <option>Más de 1 hora</option>
+                                                        <option>Más de 2 horas</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                            <!--Fin Select-->
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
-                </div> <!-- fin card Motivo de consulta-->
-								
+                </div>
             </div>
-							
-						
-              <!-- /End replace -->
-            </div>
-						
-						<div class="bg-gray-100 w-full px-6 py-5">
-							<div class="bg-white shadow px-4 py-5 sm:rounded-lg sm:p-6">
-									<div class="md:grid md:grid-cols-3 md:gap-6">
-											<div class="md:col-span-3">
-													<h3 class="text-lg font-medium leading-6 text-gray-900">Intensidad </h3>
-													<div class="border-t border-gray-200 px-0 sm:my-4 sm:mx-0"></div>
-						<legend class="text-base font-medium text-gray-900"></legend>
-						
-						<div class="mt-4 space-y-4 ">
-								<div class="flex items-start">
-											
-										<div class="grid grid-cols-1">
-											<div class="mt-4">
-												<label  class="medium">
-													<input type="checkbox" id="leve" name="leve" class="checkbox"/>
-													Leve
-												</label>
-											</div>
-											<div class="mt-4">
-												<label  class="medium">
-													<input type="checkbox" id="moderate" name="moderate" class="checkbox"/>
-													Moderada
-												</label>
-											</div>
-											<div class="mt-4">
-												<label  class="medium">
-													<input type="checkbox" id="intense" name="intense" class="checkbox"/>
-													Intensa
-												</label>
-											</div>
-																																
-										</div>
 
-								</div>
-								
-				</fieldset>
-			<!--Select-->
-							
-			<div class="col-span-6 sm:col-span-6 mt-4">
-				<div>
-				<label id="listbox-label-frequency" class="text-sm">
-						Frecuencia (días de la semana)
-				</label>
-				<div class="max-w-xs mt-1">
-						<div
-										x-data="select({ data: { 1: '1', 2: '2', 3: '3', 4: '4',5: '5', 6: '6', 7: '7'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'Frecuencia', placeholder: 'Elige una opción' })"
-										x-init="init()"
-										@click.away="closeListbox()"
-										@keydown.escape="closeListbox()"
-										class="relative"
-						>
-										<span class="inline-block w-full rounded-md shadow-sm">
-													<button type="button"
-																	x-ref="button"
-																	@click="toggleListboxVisibility()"
-																	:aria-expanded="open"
-																	aria-haspopup="listbox"
-																	class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-													>
-																<span
-																				x-show="! open"
-																				x-text="value in options ? options[value] : placeholder"
-																				:class="{ 'text-gray-500': ! (value in options) }"
-																				class="block truncate"
-																></span>
-		
-																<input
-																				x-ref="search"
-																				x-show="open"
-																				x-model="search"
-																				@keydown.enter.stop.prevent="selectOption()"
-																				@keydown.arrow-up.prevent="focusPreviousOption()"
-																				@keydown.arrow-down.prevent="focusNextOption()"
-																				type="search"
-																				class="w-full h-full form-control focus:outline-none"
-																/>
-		
-																<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																		<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																				<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																							stroke-linejoin="round"></path>
-																		</svg>
-																</span>
-													</button>
-										</span>
-		
-								<div
-												x-show="open"
-												x-transition:leave="transition ease-in duration-100"
-												x-transition:leave-start="opacity-100"
-												x-transition:leave-end="opacity-0"
-												x-cloak
-												class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-								>
-										<ul
-														x-ref="listbox"
-														@keydown.enter.stop.prevent="selectOption()"
-														@keydown.arrow-up.prevent="focusPreviousOption()"
-														@keydown.arrow-down.prevent="focusNextOption()"
-														role="listbox"
-														:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-														tabindex="-1"
-														class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-										>
-												<template x-for="(key, index) in Object.keys(options)" :key="index">
-														<li
-																		:id="name + 'Option' + focusedOptionIndex"
-																		@click="selectOption()"
-																		@mouseenter="focusedOptionIndex = index"
-																		@mouseleave="focusedOptionIndex = null"
-																		role="option"
-																		:aria-selected="focusedOptionIndex === index"
-																		:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																		class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-														>
-																		<span x-text="Object.values(options)[index]"
-																					:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																					class="block font-normal truncate"
-																		></span>
-		
-																<span
-																				x-show="key === value"
-																				:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																				class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																>
-																				<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																						<path fill-rule="evenodd"
-																									d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																									clip-rule="evenodd"/>
-																				</svg>
-																		</span>
-														</li>
-												</template>
-		
-												<div
-																x-show="! Object.keys(options).length"
-																x-text="emptyOptionsMessage"
-																class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-										</ul>
-								</div>
-						</div>
-		
-						<script>
-								function select(config) {
-										return {
-												data: config.data,
-		
-												emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-		
-												focusedOptionIndex: null,
-		
-												name: config.name,
-		
-												open: false,
-		
-												options: {},
-		
-												placeholder: config.placeholder ?? 'Select an option',
-		
-												search: '',
-		
-												value: config.value,
-		
-												closeListbox: function () {
-														this.open = false
-		
-														this.focusedOptionIndex = null
-		
-														this.search = ''
-												},
-		
-												focusNextOption: function () {
-														if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-		
-														if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-		
-														this.focusedOptionIndex++
-		
-														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																block: "center",
-														})
-												},
-		
-												focusPreviousOption: function () {
-														if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-		
-														if (this.focusedOptionIndex <= 0) return
-		
-														this.focusedOptionIndex--
-		
-														this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																block: "center",
-														})
-												},
-		
-												init: function () {
-														this.options = this.data
-		
-														if (!(this.value in this.options)) this.value = null
-		
-														this.$watch('search', ((value) => {
-																if (!this.open || !value) return this.options = this.data
-		
-																this.options = Object.keys(this.data)
-																		.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																		.reduce((options, key) => {
-																				options[key] = this.data[key]
-																				return options
-																		}, {})
-														}))
-												},
-		
-												selectOption: function () {
-														if (!this.open) return this.toggleListboxVisibility()
-		
-														this.value = Object.keys(this.options)[this.focusedOptionIndex]
-		
-														this.closeListbox()
-												},
-		
-												toggleListboxVisibility: function () {
-														if (this.open) return this.closeListbox()
-		
-														this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-		
-														if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-		
-														this.open = true
-		
-														this.$nextTick(() => {
-																this.$refs.search.focus()
-		
-																this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																		block: "center"
-																})
-														})
-												},
-										}
-								}
-						</script>
-				</div>
-		</div>
-			<!--Fin select-->
-
-			
-						<!--Select-->
-							
-						<div class="col-span-6 sm:col-span-6 mt-4">
-							<div>
-							<label id="listbox-label-duration" class="text-sm">
-									Duración
-							</label>
-							<div class="max-w-screen-2xl mt-1">
-									<div
-													x-data="select({ data: {menos: 'Menos de 30 minutos', 30: '30 minutos a 1 hora', 1: 'Más de 1 hora', 2: 'Más de 2 horas'}, emptyOptionsMessage: 'No se ha seleccionado una opción.', name: 'nivel_de_actividad_fisica', placeholder: 'Elige una opción' })"
-													x-init="init()"
-													@click.away="closeListbox()"
-													@keydown.escape="closeListbox()"
-													class="relative"
-									>
-													<span class="inline-block w-full rounded-md shadow-sm">
-																<button type="button"
-																				x-ref="button"
-																				@click="toggleListboxVisibility()"
-																				:aria-expanded="open"
-																				aria-haspopup="listbox"
-																				class="relative z-0 w-full py-2 pl-3 pr-10 text-left transition duration-150 ease-in-out bg-white border border-gray-300 rounded-md cursor-default focus:outline-none focus:shadow-outline-blue focus:border-blue-300 sm:text-sm sm:leading-5"
-																>
-																			<span
-																							x-show="! open"
-																							x-text="value in options ? options[value] : placeholder"
-																							:class="{ 'text-gray-500': ! (value in options) }"
-																							class="block truncate"
-																			></span>
-					
-																			<input
-																							x-ref="search"
-																							x-show="open"
-																							x-model="search"
-																							@keydown.enter.stop.prevent="selectOption()"
-																							@keydown.arrow-up.prevent="focusPreviousOption()"
-																							@keydown.arrow-down.prevent="focusNextOption()"
-																							type="search"
-																							class="w-full h-full form-control focus:outline-none"
-																			/>
-					
-																			<span class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-																					<svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="none" stroke="currentColor">
-																							<path d="M7 7l3-3 3 3m0 6l-3 3-3-3" stroke-width="1.5" stroke-linecap="round"
-																										stroke-linejoin="round"></path>
-																					</svg>
-																			</span>
-																</button>
-													</span>
-					
-											<div
-															x-show="open"
-															x-transition:leave="transition ease-in duration-100"
-															x-transition:leave-start="opacity-100"
-															x-transition:leave-end="opacity-0"
-															x-cloak
-															class="absolute z-10 w-full mt-1 bg-white rounded-md shadow-lg"
-											>
-													<ul
-																	x-ref="listbox"
-																	@keydown.enter.stop.prevent="selectOption()"
-																	@keydown.arrow-up.prevent="focusPreviousOption()"
-																	@keydown.arrow-down.prevent="focusNextOption()"
-																	role="listbox"
-																	:aria-activedescendant="focusedOptionIndex ? name + 'Option' + focusedOptionIndex : null"
-																	tabindex="-1"
-																	class="py-1 overflow-auto text-base leading-6 rounded-md shadow-xs max-h-60 focus:outline-none sm:text-sm sm:leading-5"
-													>
-															<template x-for="(key, index) in Object.keys(options)" :key="index">
-																	<li
-																					:id="name + 'Option' + focusedOptionIndex"
-																					@click="selectOption()"
-																					@mouseenter="focusedOptionIndex = index"
-																					@mouseleave="focusedOptionIndex = null"
-																					role="option"
-																					:aria-selected="focusedOptionIndex === index"
-																					:class="{ 'text-white bg-indigo-600': index === focusedOptionIndex, 'text-gray-900': index !== focusedOptionIndex }"
-																					class="relative py-2 pl-3 text-gray-900 cursor-default select-none pr-9"
-																	>
-																					<span x-text="Object.values(options)[index]"
-																								:class="{ 'font-semibold': index === focusedOptionIndex, 'font-normal': index !== focusedOptionIndex }"
-																								class="block font-normal truncate"
-																					></span>
-					
-																			<span
-																							x-show="key === value"
-																							:class="{ 'text-white': index === focusedOptionIndex, 'text-indigo-600': index !== focusedOptionIndex }"
-																							class="absolute inset-y-0 right-0 flex items-center pr-4 text-indigo-600"
-																			>
-																							<svg class="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-																									<path fill-rule="evenodd"
-																												d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-																												clip-rule="evenodd"/>
-																							</svg>
-																					</span>
-																	</li>
-															</template>
-					
-															<div
-																			x-show="! Object.keys(options).length"
-																			x-text="emptyOptionsMessage"
-																			class="px-3 py-2 text-gray-900 cursor-default select-none"></div>
-													</ul>
-											</div>
-									</div>
-					
-									<script>
-											function select(config) {
-													return {
-															data: config.data,
-					
-															emptyOptionsMessage: config.emptyOptionsMessage ?? 'No results match your search.',
-					
-															focusedOptionIndex: null,
-					
-															name: config.name,
-					
-															open: false,
-					
-															options: {},
-					
-															placeholder: config.placeholder ?? 'Select an option',
-					
-															search: '',
-					
-															value: config.value,
-					
-															closeListbox: function () {
-																	this.open = false
-					
-																	this.focusedOptionIndex = null
-					
-																	this.search = ''
-															},
-					
-															focusNextOption: function () {
-																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = Object.keys(this.options).length - 1
-					
-																	if (this.focusedOptionIndex + 1 >= Object.keys(this.options).length) return
-					
-																	this.focusedOptionIndex++
-					
-																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																			block: "center",
-																	})
-															},
-					
-															focusPreviousOption: function () {
-																	if (this.focusedOptionIndex === null) return this.focusedOptionIndex = 0
-					
-																	if (this.focusedOptionIndex <= 0) return
-					
-																	this.focusedOptionIndex--
-					
-																	this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																			block: "center",
-																	})
-															},
-					
-															init: function () {
-																	this.options = this.data
-					
-																	if (!(this.value in this.options)) this.value = null
-					
-																	this.$watch('search', ((value) => {
-																			if (!this.open || !value) return this.options = this.data
-					
-																			this.options = Object.keys(this.data)
-																					.filter((key) => this.data[key].toLowerCase().includes(value.toLowerCase()))
-																					.reduce((options, key) => {
-																							options[key] = this.data[key]
-																							return options
-																					}, {})
-																	}))
-															},
-					
-															selectOption: function () {
-																	if (!this.open) return this.toggleListboxVisibility()
-					
-																	this.value = Object.keys(this.options)[this.focusedOptionIndex]
-					
-																	this.closeListbox()
-															},
-					
-															toggleListboxVisibility: function () {
-																	if (this.open) return this.closeListbox()
-					
-																	this.focusedOptionIndex = Object.keys(this.options).indexOf(this.value)
-					
-																	if (this.focusedOptionIndex < 0) this.focusedOptionIndex = 0
-					
-																	this.open = true
-					
-																	this.$nextTick(() => {
-																			this.$refs.search.focus()
-					
-																			this.$refs.listbox.children[this.focusedOptionIndex].scrollIntoView({
-																					block: "center"
-																			})
-																	})
-															},
-													}
-											}
-									</script>
-							</div>
-					</div>
-						<!--Fin select-->
-          </div>
-			</div>
-						</div>
-											</div>
-									</div>
-							</div>
         </div>
-				
-      </div>
+        
+    </div>
+</turbo-frame>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get 'slideover_expedients/anthropometric'
   get 'slideover_expedients/physical_activity'
   get 'slideover_expedients/notes'
- get 'expedients/anthropometric'
+  get 'expedients/anthropometric'
   get 'expedients/general'
   get 'expedients/habits'
   get 'expedients/history'


### PR DESCRIPTION
* Tabs, slide-over and select function

* Tabs, slide-over and select function

* Add Chartkick and AlpineJS as a module

* Add Chartkick and AlpineJS as a module

* Grouping imports and sorting gems alphabetically

* Add stimulus controller for expident's tabs

* Tabs, slide-over and select function

* Tabs, slide-over and select function

* Add Chartkick and AlpineJS as a module

* Add Chartkick and AlpineJS as a module

* Grouping imports and sorting gems alphabetically

* Add stimulus controller for expident's tabs

* Resolving some conflicts

* Changing the URL for the tabs function

* Add new controller for tabs

* Add generic controller for tabs function

* Fix: Split tabs function in a single view using Turbo-Frames

* Add function to open the modal in the habit table

* Add generic controller for tabs function

* Add function to open the modal in the habit table

* Add to function open the modal in the habit table

* Updating repository

* Consuming real paths

* Adding index in the new route

Co-authored-by: Miguel Gomez <miggr14@gmail.com>